### PR TITLE
Fix creation of SPNs for short hostnames

### DIFF
--- a/msktkrb5.cpp
+++ b/msktkrb5.cpp
@@ -366,9 +366,9 @@ void update_keytab(msktutil_flags *flags)
     if (!flags->userPrincipalName.empty()) {
         add_principal_keytab(flags->userPrincipalName, flags);
     }
-    /* add host/sAMAccountName */
+    /* add host/<short_hostname> */
     if (!flags->use_service_account) {
-        add_principal_keytab("host/" + flags->sAMAccountName_nodollar, flags);
+        add_principal_keytab("host/" + get_short_hostname(flags), flags);
     }
     for (size_t i = 0; i < flags->ad_principals.size(); ++i) {
         if ((flags->userPrincipalName.empty()) ||

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -405,7 +405,13 @@ std::string get_host_os()
 }
 
 
-std::string get_short_hostname(msktutil_flags *flags)
+/* Default sAMAccountName for current host:
+   Use lowercase FQDN, strip realm if applicable, convert remaining dots to dashes.
+   Eg. foo.example.com in realm EXAMPLE.COM -> foo
+       foo.subdomain1.example.com in realm EXAMPLE.COM -> foo-subdomain1
+       foo.subdomain1.example.com in realm OTHEREXAMPLE.COM -> foo-subdomain1-example-com
+ */
+std::string get_default_samaccountname(msktutil_flags *flags)
 {
     std::string long_hostname = flags->hostname;
 
@@ -414,25 +420,25 @@ std::string get_short_hostname(msktutil_flags *flags)
         *it = std::tolower(*it);
     }
 
-    std::string short_hostname = long_hostname;
+    std::string samaccountname = long_hostname;
 
     size_t dot = std::string::npos;
     while ((dot = long_hostname.find('.', dot + 1)) != std::string::npos) {
         if (long_hostname.compare(dot + 1,
                                   std::string::npos,
                                   flags->lower_realm_name) == 0) {
-            short_hostname = long_hostname.substr(0, dot);
+            samaccountname = long_hostname.substr(0, dot);
             break;
         }
     }
 
     /* Replace any remaining dots with dashes */
-    for (size_t i = 0; i < short_hostname.length(); ++i) {
-        if (short_hostname[i] == '.') {
-            short_hostname[i] = '-';
+    for (size_t i = 0; i < samaccountname.length(); ++i) {
+        if (samaccountname[i] == '.') {
+            samaccountname[i] = '-';
         }
     }
 
-    VERBOSE("Determined short hostname: %s", short_hostname.c_str());
-    return short_hostname;
+    VERBOSE("Determined sAMAccountName: %s", samaccountname.c_str());
+    return samaccountname;
 }

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -442,3 +442,14 @@ std::string get_default_samaccountname(msktutil_flags *flags)
     VERBOSE("Determined sAMAccountName: %s", samaccountname.c_str());
     return samaccountname;
 }
+
+/* Return first component of FQDN set in flags->hostname */
+std::string get_short_hostname(msktutil_flags *flags)
+{
+    std::string long_hostname = flags->hostname;
+    std::string short_hostname = long_hostname.substr(0, long_hostname.find('.'));
+    std::transform(short_hostname.begin(), short_hostname.end(), short_hostname.begin(), ::tolower);
+
+    VERBOSE("Determined short hostname: %s", short_hostname.c_str());
+    return short_hostname;
+}

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -233,7 +233,7 @@ int finalize_exec(msktutil_exec *exec, msktutil_flags *flags)
                 );
             exit(1);
         } else {
-            flags->sAMAccountName = get_short_hostname(flags)  + "$";
+            flags->sAMAccountName = get_default_samaccountname(flags)  + "$";
         }
     }
 

--- a/msktutil.h
+++ b/msktutil.h
@@ -265,7 +265,7 @@ extern void get_default_ou(msktutil_flags *);
 extern void ldap_get_base_dn(msktutil_flags *);
 extern std::string complete_hostname(const std::string &,
                                      bool no_canonical_name = false);
-extern std::string get_short_hostname(msktutil_flags *);
+extern std::string get_default_samaccountname(msktutil_flags *);
 extern int flush_keytab(msktutil_flags *);
 extern void cleanup_keytab(msktutil_flags *);
 extern void update_keytab(msktutil_flags *);

--- a/msktutil.h
+++ b/msktutil.h
@@ -266,6 +266,7 @@ extern void ldap_get_base_dn(msktutil_flags *);
 extern std::string complete_hostname(const std::string &,
                                      bool no_canonical_name = false);
 extern std::string get_default_samaccountname(msktutil_flags *);
+extern std::string get_short_hostname(msktutil_flags *);
 extern int flush_keytab(msktutil_flags *);
 extern void cleanup_keytab(msktutil_flags *);
 extern void update_keytab(msktutil_flags *);


### PR DESCRIPTION
msktutil adds a default keytab entry for `host/<sAMAccountName>` while `host/<shorthostname>` was actually intended. Commonly, both names match, but problems will arise if they don't: The generated SPN is actually invalid because it is unknown in AD, whereas the valid SPN based on the short hostname may be required, but is missing. This set of changes corrects this, and cleans up a few of the touched code paths.
