### PR TITLE
Improve robustness to errors in DNS entries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,7 +29,7 @@ $(PROG) : $(objects)
 	@$(ECHO) "Assembling $(PROG)"
 	$(CXX) $(LDFLAGS) $(objects) $(LIBS) -o $(PROG)
 
-%.o : %.cpp msktutil.h krb5wrap.h config.h ldapconnection.h
+%.o : %.cpp msktutil.h msktname.h krb5wrap.h config.h ldapconnection.h
 	@$(ECHO) "Compiling $<"
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -198,7 +198,7 @@ bool DnsSrvHost::validate(bool nocanon) {
     return ! validated_name.empty();
 };
 
-DnsSrvQuery::DnsSrvQuery(std::string domain, std::string service, std::string protocol)
+DnsSrvQuery::DnsSrvQuery(const std::string& domain, const std::string& service, const std::string& protocol)
 {
 #if defined(HAVE_LIBUDNS)
     struct dns_ctx *nsctx = NULL;

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -166,7 +166,7 @@ bool DnsSrvHost::validate(bool nocanon) {
             VERBOSE("Failed to open socket");
             continue;
         }
-        if (connect(sock, (struct sockaddr *) &addr, 2) == -1) {
+        if (connect(sock, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
             VERBOSE("LDAP connection (%d) failed", i);
             continue;
         }

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -167,7 +167,7 @@ bool DnsSrvHost::validate(bool nocanon) {
             VERBOSE("Failed to open socket");
             continue;
         }
-        if (connect(sock, (struct sockaddr *) &addr, 2) != -1) {
+        if (connect(sock, (struct sockaddr *) &addr, 2) == -1) {
             VERBOSE("LDAP connection (%d) failed", i);
             continue;
         }

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -8,8 +8,8 @@
  * (C) 2009-2010 Doug Engert (deengert@anl.gov)
  * (C) 2010 James Y Knight (foom@fuhm.net)
  * (C) 2010-2013 Ken Dreyer <ktdreyer at ktdreyer.com>
- * (C) 2012-2015 Mark Proehl <mark at mproehl.net>
- * (C) 2012-2015 Olaf Flebbe <of at oflebbe.de>
+ * (C) 2012-2017 Mark Proehl <mark at mproehl.net>
+ * (C) 2012-2017 Olaf Flebbe <of at oflebbe.de>
  * (C) 2013-2017 Daniel Kobras <d.kobras at science-computing.de>
  *
     This program is free software; you can redistribute it and/or modify

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -30,7 +30,6 @@
  */
 
 #include "msktutil.h"
-#include "msktname.h"
 
 #include <algorithm>
 #include <cctype>

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -8,8 +8,8 @@
  * (C) 2009-2010 Doug Engert (deengert@anl.gov)
  * (C) 2010 James Y Knight (foom@fuhm.net)
  * (C) 2010-2013 Ken Dreyer <ktdreyer at ktdreyer.com>
- * (C) 2012-2017 Mark Proehl <mark at mproehl.net>
- * (C) 2012-2017 Olaf Flebbe <of at oflebbe.de>
+ * (C) 2012-2015 Mark Proehl <mark at mproehl.net>
+ * (C) 2012-2015 Olaf Flebbe <of at oflebbe.de>
  * (C) 2013-2017 Daniel Kobras <d.kobras at science-computing.de>
  *
     This program is free software; you can redistribute it and/or modify
@@ -30,20 +30,11 @@
  */
 
 #include "msktutil.h"
+#include "msktname.h"
 
-#if defined(HAVE_LIBUDNS)
-#include <udns.h>
-#elif defined(HAVE_NS_INITPARSE) && defined(HAVE_RES_SEARCH)
-#include <arpa/inet.h>
-#include <arpa/nameser.h>
-#include <resolv.h>
-
-#if !defined(NS_MAXMSG)
-#define NS_MAXMSG 65535
-#endif
-#endif
-#include <netinet/in.h>
+#include <algorithm>
 #include <cctype>
+
 std::string complete_hostname(const std::string &hostname,
                               bool no_canonical_name)
 {
@@ -143,86 +134,87 @@ std::string get_default_hostname(bool no_canonical_name)
 #endif
 }
 
-#if defined(HAVE_NS_INITPARSE) && defined(HAVE_RES_SEARCH)
-struct msktutil_dcdata {
-    char srvname[NS_MAXDNAME];
-    unsigned int priority;
-    unsigned int weight;
-    unsigned int port;
+bool DnsSrvHost::validate(bool nocanon) {
+    int sock = -1;
+    struct hostent *host;
+
+    if (!validated_name.empty()) {
+        return true;
+    }
+
+    host = gethostbyname(srvname.c_str());
+
+    if (!host) {
+        VERBOSE("Error: gethostbyname failed for %s\n", srvname.c_str());
+        return false;
+    }
+
+    VERBOSE("Found DC: %s. Checking availability...", srvname.c_str());
+
+    for (int i = 0; host->h_addr_list[i]; i++) {
+        struct sockaddr_in addr;
+        struct hostent *hp;
+
+        memcpy(&(addr.sin_addr.s_addr), host->h_addr_list[i], host->h_length);
+
+        /* Now let's try and open and close a socket to see if the domain controller is up or not */
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(LDAP_PORT);
+        if (sock != -1) {
+            close(sock);
+        }
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+            VERBOSE("Failed to open socket");
+            continue;
+        }
+        if (connect(sock, (struct sockaddr *) &addr, 2) != -1) {
+            VERBOSE("LDAP connection (%d) failed", i);
+            continue;
+        }
+
+        /* See if this is the 'lowest' domain controller name... the idea is to always try to
+         * use the same domain controller. Things may become inconsistent otherwise.
+         * This optimization is only possible if we're told to canonify the hostname. Otherwise,
+         * we're not allowed to touch it, but we can make sure that it resolves to at least
+         * one working IP address. */
+        if (nocanon) {
+            validated_name = srvname;
+            break;
+        }
+        hp = gethostbyaddr((char *) &addr.sin_addr.s_addr, sizeof(addr.sin_addr.s_addr), AF_INET);
+        if (!hp) {
+            VERBOSE("Error: gethostbyaddr failed for %s\n", srvname.c_str());
+            continue;
+        }
+        if (!validated_name.empty() && std::string(hp->h_name) > validated_name) {
+            VERBOSE("Connection to DC %s ok, but we already prefer %s", hp->h_name, validated_name.c_str());
+            continue;
+        }
+        validated_name = std::string(hp->h_name);
+
+    }
+    if (sock != -1) {
+        close(sock);
+    }
+    return ! validated_name.empty();
 };
 
-/* A quirk in glibc < 2.9 makes us pick up a symbol marked
- * GLIBC_PRIVATE if we use ns_get16 from libresolv, leading to a
- * broken RPM that can only be installed with --nodeps. As a
- * workaround, use a private version of ns_get16--it's simple
- * enough. */
-static unsigned int msktutil_ns_get16(const unsigned char *src)
-{
-    return (unsigned int) (((uint16_t)src[0] << 8) | ((uint16_t)src[1]));
-}
-
-
-static int compare_priority_weight(const void *a, const void *b)
-{
-    struct msktutil_dcdata *ia = (struct msktutil_dcdata *)a;
-    struct msktutil_dcdata *ib = (struct msktutil_dcdata *)b;
-
-    if (ia->priority > ib->priority) {
-        return 1;
-    }
-
-    if (ia->priority < ib->priority) {
-        return -1;
-    }
-
-    if (ia->weight > ib->weight) {
-        return -1;
-    }
-
-    if (ia->weight < ib->weight) {
-        return 1;
-    }
-
-    return 0;
-}
-#endif
-
-
-static std::string get_dc_host_from_srv_rr(const std::string &domain,
-                                           const std::string &protocol)
+DnsSrvQuery::DnsSrvQuery(std::string domain, std::string service, std::string protocol)
 {
 #if defined(HAVE_LIBUDNS)
     struct dns_ctx *nsctx = NULL;
-    std::string dc; /* default: empty == error */
 
     dns_reset(NULL);
     if ((nsctx = dns_new(NULL)) != NULL) {
         if (dns_init(nsctx, 1) >= 0) {
             struct dns_rr_srv *srv;
 
-            if ((srv = dns_resolve_srv(nsctx, domain.c_str(),
-                                       "kerberos",
-                                       protocol.c_str(),
-                                       DNS_NOSRCH)) != NULL) {
-                /* determine preferred dc in a really, really
-                 * pedestrian fashion to avoid mucking about with
-                 * separate dcdata structure, qsort and comparison
-                 * function */
-                struct dns_srv *bestdc = srv->dnssrv_srv;
-                int i;
+            if ((srv = dns_resolve_srv(nsctx, domain.c_str(), service.c_str(),
+                            protocol.c_str(), DNS_NOSRCH)) != NULL) {
 
-                for (i = 1; i < srv->dnssrv_nrr; i++) {
-                    /* dc ist "better" if priority is lower or for
-                     * equal priority if weight is higher */
-                    if (srv->dnssrv_srv[i].priority < bestdc->priority ||
-                        (srv->dnssrv_srv[i].priority == bestdc->priority &&
-                         srv->dnssrv_srv[i].weight > bestdc->weight)) {
-                        bestdc = &(srv->dnssrv_srv[i]);
-                        continue;
-                    }
+                for (int i = 0; i < srv->dnssrv_nrr; i++) {
+                    m_results.push_back(DnsSrvHost(srv->dnssrv_srv[i]);
                 }
-
-                dc = bestdc->name;
                 free(srv);
             }
         }
@@ -230,165 +222,83 @@ static std::string get_dc_host_from_srv_rr(const std::string &domain,
         dns_close(nsctx);
         free(nsctx);
     }
-
-    return dc;
 #elif defined(HAVE_NS_INITPARSE) && defined(HAVE_RES_SEARCH)
     unsigned char response[NS_MAXMSG];
     int len;
-    int i;
-    int j=0; /* my not so smart compiler warns me about: 'j' may be
-              * used uninitialized in this function ... */
     ns_msg reshandle;
     ns_rr rr;
-    struct msktutil_dcdata alldcs[MAX_DOMAIN_CONTROLLERS];
-    const std::string krbdnsquery = "_kerberos._" + protocol + "." + domain;
+    const std::string krbdnsquery = "_" + service + "._" + protocol + "." + domain;
 
-    if ((len=res_search(krbdnsquery.c_str(),
-                        ns_c_in,
-                        ns_t_srv,
-                        response,
-                        sizeof(response))) > 0) {
-        if (ns_initparse(response, len, &reshandle) >= 0) {
-            if ((len=ns_msg_count(reshandle, ns_s_an)) > 0) {
-                for (i=0, j=0; i<len && j<MAX_DOMAIN_CONTROLLERS; i++) {
-                    if (ns_parserr(&reshandle, ns_s_an, i, &rr)) {
-                        /* Ignore records we cannot parse, this is non
-                         * fatal. */
+    VERBOSE("Running DNS SRV query for %s", krbdnsquery.c_str());
+    if ((len=res_search(krbdnsquery.c_str(), ns_c_in, ns_t_srv, response, sizeof(response))) > 0) {
+        if (ns_initparse(response,len,&reshandle) >= 0) {
+            if ((len=ns_msg_count(reshandle,ns_s_an)) > 0) {
+                for (int i = 0; i<len; i++) {
+                    if (ns_parserr(&reshandle,ns_s_an,i,&rr) ||
+                        ns_rr_class(rr) != ns_c_in ||
+                        ns_rr_type(rr) != ns_t_srv) {
+                        // Ignore records we cannot parse, this is non fatal.
+                        VERBOSE("Skipping invalid record %d", i);
                         continue;
                     }
-                    if (ns_rr_class(rr) == ns_c_in &&
-                        ns_rr_type(rr) == ns_t_srv) {
-
-                        /*
-                         * Process DNS SRV
-                         *
-                         * RR                        TTL Class Type Priority Weight Port Target
-                         *  _kerberos._tcp.my.realm. 600 IN    SRV         0  10000   88 dcserverXX.my.realm.
-                         */
-                        alldcs[j].priority = msktutil_ns_get16(ns_rr_rdata(rr));
-                        alldcs[j].weight   = msktutil_ns_get16(ns_rr_rdata(rr)
-                                                               + NS_INT16SZ);
-                        alldcs[j].port     = msktutil_ns_get16(ns_rr_rdata(rr)
-                                                               + 2*NS_INT16SZ); /* we do not really need it... */
-                        dn_expand(ns_msg_base(reshandle),
-                                  ns_msg_base(reshandle)+ns_msg_size(reshandle),
-                                  ns_rr_rdata(rr) + 3*NS_INT16SZ,
-                                  alldcs[j].srvname, sizeof(char)*NS_MAXDNAME);
-                        j++;
-                    }
+                    m_results.push_back(DnsSrvHost(reshandle, rr));
                 }
             }
         }
     }
-
-    if (j) {
-        /* and get the 'top' one from the list. */
-        qsort(&alldcs,
-              j,
-              sizeof(struct msktutil_dcdata),
-              compare_priority_weight);
-        return std::string(alldcs[0].srvname, strlen(alldcs[0].srvname));
-    }
 #endif
-    return std::string();
+    std::sort(m_results.begin(), m_results.end());
 }
 
-
-std::string get_dc_host(const std::string &realm_name,
-                        const std::string &site_name,
+std::string get_dc_host(const std::string &realm_name, const std::string &site_name,
                         const bool no_reverse_lookups)
 {
     std::string dc;
-    struct hostent *host;
-    struct sockaddr_in addr;
-    struct hostent *hp;
-    int sock;
     int i;
-    std::string dcsrv;
+    DnsSrvQuery dcsrvs;
+    std::string bestdc;
     std::string protocols[] = { "tcp", "udp" };
 
     if (!site_name.empty()) {
         for (i = 0; i < (int)(sizeof(protocols) / sizeof(protocols[0])); i++) {
-            VERBOSE("Attempting to find site-specific Domain Controller "
-                    "to use via DNS SRV record in domain %s for site %s and "
-                    "procotol %s",
-                    realm_name.c_str(),
-                    site_name.c_str(),
-                    protocols[i].c_str());
-            dcsrv = get_dc_host_from_srv_rr(
-                site_name + "._sites." + realm_name, protocols[i]);
-            if (!dcsrv.empty()) {
+            VERBOSE("Attempting to find site-specific Domain Controller to use via "
+                            "DNS SRV record in domain %s for site %s and procotol %s",
+                            realm_name.c_str(), site_name.c_str(), protocols[i].c_str());
+            dcsrvs = DnsSrvQuery(site_name + "._sites." + realm_name, "kerberos", protocols[i]);
+            if (!dcsrvs.empty()) {
                 break;
             }
         }
     }
 
-    if (dcsrv.empty()) {
+    if (dcsrvs.empty()) {
         for (i = 0; i < (int)(sizeof(protocols) / sizeof(protocols[0])); i++) {
             VERBOSE("Attempting to find Domain Controller to use via "
                             "DNS SRV record in domain %s for procotol %s",
                             realm_name.c_str(), protocols[i].c_str());
-            dcsrv = get_dc_host_from_srv_rr(realm_name, protocols[i]);
-            if (!dcsrv.empty()) {
+            dcsrvs = DnsSrvQuery(realm_name, "kerberos", protocols[i]);
+            if (!dcsrvs.empty()) {
                 break;
             }
         }
     }
 
-    if (dcsrv.empty()) {
+    if (dcsrvs.empty()) {
         VERBOSE("Attempting to find a Domain Controller to use (DNS domain)");
-        dcsrv = realm_name;
+        dcsrvs = DnsSrvQuery(DnsSrvHost(realm_name, 0, 0, 0));
     }
 
-    host = gethostbyname(dcsrv.c_str());
-    if (!host) {
-        fprintf(stderr, "Error: gethostbyname failed \n");
-        return "";
+    for (std::vector<DnsSrvHost>::iterator it=dcsrvs.begin(); it != dcsrvs.end(); it++) {
+        if (it->validate(no_reverse_lookups)) {
+            bestdc = it->name();
+            break;
+	}
     }
 
-    VERBOSE("Found DC: %s", dcsrv.c_str());
-    if (no_reverse_lookups) {
-        return dcsrv;
-    }
+    VERBOSE("Found preferred Domain Controller: %s", bestdc.c_str());
 
-    VERBOSE("Canonicalizing DC through forward/reverse lookup");
-    for (i = 0; host->h_addr_list[i]; i++) {
-        memcpy(&(addr.sin_addr.s_addr), host->h_addr_list[i], host->h_length);
-        hp = gethostbyaddr((char *) &addr.sin_addr.s_addr,
-                           sizeof(addr.sin_addr.s_addr),
-                           AF_INET);
-        if (!hp) {
-            fprintf(stderr, "Error: gethostbyaddr failed \n");
-            continue;
-        }
-
-        /* Now let's try and open and close a socket to see if the
-         * domain controller is up or not */
-        addr.sin_family = AF_INET;
-        addr.sin_port = htons(LDAP_PORT);
-        sock = socket(AF_INET, SOCK_STREAM, 0);
-        connect(sock, (struct sockaddr *) &addr, 2);
-        if (sock) {
-            close(sock);
-            /* See if this is the 'lowest' domain controller
-             * name... the idea is to always try to use the same
-             * domain controller.  Things may become inconsitent
-             * otherwise */
-            if (dc.empty()) {
-                dc = std::string(hp->h_name);
-            } else {
-                if (0 > dc.compare(hp->h_name)) {
-                    dc = std::string(hp->h_name);
-                }
-            }
-        }
-    }
-    endhostent();
-
-    VERBOSE("Found Domain Controller: %s", dc.c_str());
-    return dc;
+    return bestdc;
 }
-
 
 std::string get_host_os()
 {

--- a/msktname.h
+++ b/msktname.h
@@ -66,7 +66,7 @@ private:
     unsigned int m_weight;
     unsigned int m_port;
 public:
-    DnsSrvHost(std::string name, unsigned int priority, unsigned int weight, unsigned int port)
+    DnsSrvHost(const std::string& name, unsigned int priority, unsigned int weight, unsigned int port)
         : srvname(name),
           validated_name(""),
           m_priority(priority),
@@ -120,10 +120,10 @@ private:
     std::vector<DnsSrvHost> m_results;
 public:
     DnsSrvQuery() {};
-    DnsSrvQuery(DnsSrvHost host) {
+    DnsSrvQuery(const DnsSrvHost& host) {
         m_results.push_back(host);
     };
-    DnsSrvQuery(std::string domain, std::string service, std::string protocol);
+    DnsSrvQuery(const std::string& domain, const std::string& service, const std::string& protocol);
     bool empty() { return m_results.empty(); };
     std::vector<DnsSrvHost>::iterator begin() { return m_results.begin(); };
     std::vector<DnsSrvHost>::iterator end() { return m_results.end(); };

--- a/msktname.h
+++ b/msktname.h
@@ -8,8 +8,8 @@
  * (C) 2009-2010 Doug Engert (deengert@anl.gov)
  * (C) 2010 James Y Knight (foom@fuhm.net)
  * (C) 2010-2013 Ken Dreyer <ktdreyer at ktdreyer.com>
- * (C) 2012-2015 Mark Proehl <mark at mproehl.net>
- * (C) 2012-2015 Olaf Flebbe <of at oflebbe.de>
+ * (C) 2012-2017 Mark Proehl <mark at mproehl.net>
+ * (C) 2012-2017 Olaf Flebbe <of at oflebbe.de>
  * (C) 2013-2017 Daniel Kobras <d.kobras at science-computing.de>
  *
     This program is free software; you can redistribute it and/or modify

--- a/msktname.h
+++ b/msktname.h
@@ -29,7 +29,7 @@
  *-----------------------------------------------------------------------------
  */
 
-#include "msktutil.h"
+#include "config.h"
 
 #if defined(HAVE_LIBUDNS)
 #include <udns.h>

--- a/msktname.h
+++ b/msktname.h
@@ -1,0 +1,130 @@
+/*
+ *----------------------------------------------------------------------------
+ *
+ * msktname.h
+ *
+ * (C) 2004-2006 Dan Perry (dperry@pppl.gov)
+ * (C) 2006 Brian Elliott Finley (finley@anl.gov)
+ * (C) 2009-2010 Doug Engert (deengert@anl.gov)
+ * (C) 2010 James Y Knight (foom@fuhm.net)
+ * (C) 2010-2013 Ken Dreyer <ktdreyer at ktdreyer.com>
+ * (C) 2012-2015 Mark Proehl <mark at mproehl.net>
+ * (C) 2012-2015 Olaf Flebbe <of at oflebbe.de>
+ * (C) 2013-2017 Daniel Kobras <d.kobras at science-computing.de>
+ *
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+#include "msktutil.h"
+
+#if defined(HAVE_LIBUDNS)
+#include <udns.h>
+#elif defined(HAVE_NS_INITPARSE) && defined(HAVE_RES_SEARCH)
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+#include <resolv.h>
+
+#if !defined(NS_MAXMSG)
+#define NS_MAXMSG 65535
+#endif
+#endif
+
+#include <algorithm>
+#include <cctype>
+
+#if defined(HAVE_NS_INITPARSE)
+/* A quirk in glibc < 2.9 makes us pick up a symbol marked GLIBC_PRIVATE
+ * if we use ns_get16 from libresolv, leading to a broken RPM
+ * that can only be installed with --nodeps. As a workaround,
+ * use a private version of ns_get16--it's simple enough.
+ */
+static unsigned int msktutil_ns_get16(const unsigned char *src)
+{
+    return (unsigned int) (((uint16_t)src[0] << 8) | ((uint16_t)src[1]));
+}
+#endif
+
+class DnsSrvHost {
+private:
+    std::string srvname;
+    std::string validated_name;
+    unsigned int m_priority;
+    unsigned int m_weight;
+    unsigned int m_port;
+public:
+    DnsSrvHost(std::string name, unsigned int priority, unsigned int weight, unsigned int port)
+        : srvname(name),
+          validated_name(""),
+          m_priority(priority),
+          m_weight(weight),
+          m_port(port)
+        {};
+#if defined(HAVE_LIBUDNS)
+    DnsSrvHost(struct dns_srv dnssrv& const)
+        : srvname(dnssrv.name),
+          validated_name(""),
+          m_priority(dnssrv.priority),
+          m_weight(dnssrv.weight),
+          m_port(dnssrv.port)
+        {};
+#endif
+#if defined(HAVE_NS_INITPARSE)
+    DnsSrvHost(ns_msg reshandle, ns_rr rr) : validated_name("")
+    {
+        if (ns_rr_class(rr) == ns_c_in && ns_rr_type(rr) == ns_t_srv) {
+        char name[NS_MAXDNAME];
+        m_priority = msktutil_ns_get16(ns_rr_rdata(rr));
+        m_weight   = msktutil_ns_get16(ns_rr_rdata(rr) +   NS_INT16SZ);
+        m_port     = msktutil_ns_get16(ns_rr_rdata(rr) + 2*NS_INT16SZ);
+        dn_expand(ns_msg_base(reshandle),ns_msg_base(reshandle)+ns_msg_size(reshandle),
+              ns_rr_rdata(rr) + 3*NS_INT16SZ,
+              name, sizeof(char)*NS_MAXDNAME);
+        srvname = std::string(name);
+        }
+    };
+#endif
+    std::string name() { return validated_name; };
+    unsigned int priority() { return m_priority; };
+    unsigned int weight() { return m_weight; };
+    unsigned int port() { return m_port; };
+    /* Allow to sort by prio where a lower prio number means stronger
+     * preference, ie. the lowest sorting item is the most preferred. */
+    bool operator<(const DnsSrvHost& other) const {
+        /* for ultimate confusion, prio and weight go in opposite
+         * directions, ie. we prefer lower prio, but higher weight. */
+        if (m_priority == other.m_priority)
+            return m_weight > other.m_weight;
+        
+        return m_priority < other.m_priority;
+    };
+    bool validate(bool nocanon);
+};
+
+
+class DnsSrvQuery {
+private:
+    std::vector<DnsSrvHost> m_results;
+public:
+    DnsSrvQuery() {};
+    DnsSrvQuery(DnsSrvHost host) {
+        m_results.push_back(host);
+    };
+    DnsSrvQuery(std::string domain, std::string service, std::string protocol);
+    bool empty() { return m_results.empty(); };
+    std::vector<DnsSrvHost>::iterator begin() { return m_results.begin(); };
+    std::vector<DnsSrvHost>::iterator end() { return m_results.end(); };
+};

--- a/msktutil.h
+++ b/msktutil.h
@@ -350,6 +350,7 @@ class LDAPException : public Exception
 
 #include "krb5wrap.h"
 #include "ldapconnection.h"
+#include "msktname.h"
 
 
 


### PR DESCRIPTION
When trying to deduce the domain controller to use from DNS, our current scheme just chooses one and sticks with it. If this domain controller is not fully operational for some reason, msktutil will fail, even if there were other, working domain controllers in the DNS response. The changes in this PR clean up and refactor the code doing the DNS handling, and add a validation step to make sure we only pick a domain controller that's operational.