### PR TITLE
msktutil.cpp: initialize dont_update_dnshostname flag

### DIFF
--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -1287,6 +1287,7 @@ msktutil_flags::msktutil_flags() :
     check_replication(false),
     dont_change_password(false),
     dont_expire_password(VALUE_IGNORE),
+    dont_update_dnshostname(VALUE_OFF),
     no_pac(VALUE_IGNORE),
     delegate(VALUE_IGNORE),
     ad_userAccountControl(0),


### PR DESCRIPTION
Initializer for this member was missing in the default ctor.
Thanks, valgrind!