### PR TITLE
msktname.h: fix ctor syntax for DnsSrvHost with libudns

### DIFF
--- a/msktname.cpp
+++ b/msktname.cpp
@@ -212,7 +212,7 @@ DnsSrvQuery::DnsSrvQuery(const std::string& domain, const std::string& service, 
                             protocol.c_str(), DNS_NOSRCH)) != NULL) {
 
                 for (int i = 0; i < srv->dnssrv_nrr; i++) {
-                    m_results.push_back(DnsSrvHost(srv->dnssrv_srv[i]);
+                    m_results.push_back(DnsSrvHost(srv->dnssrv_srv[i]));
                 }
                 free(srv);
             }

--- a/msktname.h
+++ b/msktname.h
@@ -74,7 +74,7 @@ public:
           m_port(port)
         {};
 #if defined(HAVE_LIBUDNS)
-    DnsSrvHost(struct dns_srv dnssrv& const)
+    DnsSrvHost(const struct dns_srv& dnssrv)
         : srvname(dnssrv.name),
           validated_name(""),
           m_priority(dnssrv.priority),


### PR DESCRIPTION
Commit 20adbc14fccaab634e2b1273cf0c3a7fffdf536b introduced an incorrect syntax for the DnsSrvHost constructor when using libudns. Change to something that actually resembles C++.
(Fixes: #93)