### PR TITLE
Apply gcc specifc warnflags only to gcc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ mandir=@mandir@
 CXX=@CXX@
 CC=@CC@
 CPPFLAGS=-I. @CPPFLAGS@
-CXXFLAGS=@CXXFLAGS@ $(WARNFLAGS)
+CXXFLAGS=@CXXFLAGS@ @WARNFLAGS@
 LDFLAGS=@LDFLAGS@
 LIBS=@LIBS@
 INSTALL=@INSTALL@
@@ -18,7 +18,6 @@ SED=@SED@
 CAT=@CAT@
 ECHO=@ECHO@
 MKDIR=@MKDIR@
-WARNFLAGS=-Wall -Wextra -Wno-write-strings
 MAN=$(PROG).1
 
 objects = krb5wrap.o msktutil.o msktkrb5.o msktldap.o msktname.o msktpass.o msktconf.o strtoll.o ldapconnection.o

--- a/configure.in
+++ b/configure.in
@@ -21,6 +21,7 @@ AC_PATH_PROGS(CP, cp)
 AC_PATH_PROGS(ECHO, echo)
 AC_PATH_PROGS(SED, sed)
 AC_PATH_PROGS(MKDIR, mkdir)
+AC_SUBST(WARNFLAGS)
 
 AC_ARG_WITH(mandir,
 [  --with-mandir=DIR       Where to put man pages ($mandir)],
@@ -64,6 +65,10 @@ AS_IF([test -z "$krb5config"],
 		[${PATH}:/usr/kerberos/bin])
 	[ krb5config="$PATH_KRB5_CONFIG"]
 ])
+
+if test x$GCC = xyes ; then
+  WARNFLAGS="-Wall -Wextra -Wno-write-strings"
+fi
 
 if test -x "$krb5config"; then
   KRB5_CPPFLAGS=`$krb5config --cflags 2>/dev/null`


### PR DESCRIPTION
The approach of pull request #95 didn't work for me. This pull  is less invasive.