### PR TITLE
Fix incomplete socket include

### DIFF
--- a/msktutil.h
+++ b/msktutil.h
@@ -47,6 +47,7 @@
 #include <time.h>
 #include <limits.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/utsname.h>
 #include <ldap.h>


### PR DESCRIPTION
FreeBSD requires `<netinet/in.h>` to be included for several socket-related structures.

This fixes:

    $ gmake
    Compiling krb5wrap.cpp
    c++ -I.  -I/usr/local/include -g -O2 -Wall -Wextra -Wno-write-strings -c krb5wrap.cpp -o krb5wrap.o
    Compiling msktutil.cpp
    c++ -I.  -I/usr/local/include -g -O2 -Wall -Wextra -Wno-write-strings -c msktutil.cpp -o msktutil.o
    Compiling msktkrb5.cpp
    c++ -I.  -I/usr/local/include -g -O2 -Wall -Wextra -Wno-write-strings -c msktkrb5.cpp -o msktkrb5.o
    Compiling msktldap.cpp
    c++ -I.  -I/usr/local/include -g -O2 -Wall -Wextra -Wno-write-strings -c msktldap.cpp -o msktldap.o
    Compiling msktname.cpp
    c++ -I.  -I/usr/local/include -g -O2 -Wall -Wextra -Wno-write-strings -c msktname.cpp -o msktname.o
    msktname.cpp:154:28: error: variable has incomplete type 'struct sockaddr_in'
            struct sockaddr_in addr;
                               ^
    msktname.cpp:154:16: note: forward declaration of 'sockaddr_in'
            struct sockaddr_in addr;
                   ^
    msktname.cpp:161:25: error: use of undeclared identifier 'htons'
            addr.sin_port = htons(LDAP_PORT);
                            ^
    2 errors generated.
    gmake: *** [Makefile:34: msktname.o] Fehler 1
    
Tested on FreeBSD 10.3, RHEL 6 and HP-UX 11.31.