### PR TITLE
Add --enable command line option to enable the account 

### DIFF
--- a/msktldap.cpp
+++ b/msktldap.cpp
@@ -504,6 +504,10 @@ void ldap_check_account_strings(msktutil_flags *flags)
                                      UF_DONT_EXPIRE_PASSWORD,
                                      flags->dont_expire_password,
                                      flags);
+    ldap_set_userAccountControl_flag(dn,
+                                     UF_ACCOUNT_DISABLE,
+                                     flags->disable_account,
+                                     flags);
 }
 
 template<typename T, size_t N>

--- a/msktutil.M
+++ b/msktutil.M
@@ -220,6 +220,10 @@ Do not update dnsHostName attribute. In some AD installations modification of th
 is not allowed (unless using administrator credentials), using this option will avoid constraint 
 violation warning.
 .TP
+--enable 
+Unsets the UF_ACCOUNT_DISABLE flag in the userAccountControl attribute.  When a computer leaves the domain
+this flag is normally set.  Generally requires administrator credentials.
+.TP
 --enctypes <integer>
 Sets the supported encryption types in the msDs-supportedEncryptionTypes field.
 

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -470,6 +470,7 @@ void do_help()
     fprintf(stdout, "Object type/attribute-setting options:\n");
     fprintf(stdout, "  --use-service-account  Create and maintain service account instead of\n");
     fprintf(stdout, "                         machine account.\n");
+    fprintf(stdout, "  --enable               Enable the account.\n");
     fprintf(stdout, "  --delegation           Set the account to be trusted for delegation.\n");
     fprintf(stdout, "  --disable-delegation   Set the account to not be trusted for\n");
     fprintf(stdout, "                         delegation.\n");
@@ -941,6 +942,12 @@ int main(int argc, char *argv [])
             continue;
         }
 
+        /* Enable the account */
+        if (!strcmp(argv[i], "--enable")) {
+            flags->disable_account = VALUE_OFF;
+            continue;
+        }
+
         /* Disable the PAC ? */
         if (!strcmp(argv[i], "--no-pac")) {
             flags->no_pac = VALUE_ON;
@@ -1310,6 +1317,7 @@ msktutil_flags::msktutil_flags() :
     dont_change_password(false),
     dont_expire_password(VALUE_IGNORE),
     dont_update_dnshostname(VALUE_OFF),
+    disable_account(VALUE_IGNORE),
     no_pac(VALUE_IGNORE),
     delegate(VALUE_IGNORE),
     ad_userAccountControl(0),

--- a/msktutil.h
+++ b/msktutil.h
@@ -93,6 +93,7 @@
 
 /* From SAM.H */
 #define UF_WORKSTATION_TRUST_ACCOUNT    0x00001000
+#define UF_ACCOUNT_DISABLE              0x00000002
 #define UF_NORMAL_ACCOUNT               0x00000200
 #define UF_DONT_EXPIRE_PASSWORD         0x00010000
 #define UF_TRUSTED_FOR_DELEGATION       0x00080000
@@ -192,6 +193,7 @@ public:
 
     msktutil_val dont_expire_password;
     msktutil_val dont_update_dnshostname;
+    msktutil_val disable_account;
     msktutil_val no_pac;
     msktutil_val delegate;
     unsigned int ad_userAccountControl; /* value AD has now */


### PR DESCRIPTION
I was missing an --enable option to enable an account that was disabled when leaving a domain before. 
During the join operation the account would be enabled so this is not useful for normal operations. 

What I do is for automated windows deployment, instead of joining using an admin account and having that one password in unattended.xml for everyone to grab, I join computers using their own machine account. The password is downloaded from a web service that runs msktutil to set it.  To be able to authenticate with the machine account, it must be enabled.

The change is simple and you already have the necessary infrastructure in the code.