### PR TITLE
Silence warning from autotools

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,8 +1,9 @@
 PROG=@PACKAGE_NAME@
 SHELL=/bin/sh
-srcdir = @srcdir@
+srcdir=@srcdir@
 VPATH=@srcdir@
 prefix=@prefix@
+datarootdir=@datarootdir@
 sbindir=$(prefix)/sbin
 mandir=@mandir@
 CXX=@CXX@


### PR DESCRIPTION
When configure is running from an autoconf V2.69 generated source a Warning is displayed:

> config.status: WARNING:  '../msktutil/Makefile.in' seems to ignore the --datarootdir setting

Pull request is silencing this warning.
See https://www.gnu.org/software/autoconf/manual/autoconf.html#Changed-Directory-Variables