### PR TITLE
Implements --use-samba-cmd option

### DIFF
--- a/msktutil.M
+++ b/msktutil.M
@@ -278,6 +278,10 @@ This operation requires administrator privileges.
 Use Samba's net changesecretpw command to locally set the machine account password in Samba's secrets.tdb.
 $PATH need to include Samba's net command.  Samba needs to be configured appropriately.
 .TP
+--use-samba-cmd <command>
+Use supplied command instead of Samba's net changesecretpw command. command will be supplied machine account
+password on standard input and shall return 0 exit code on success. 
+.TP
 --check-replication
 Wait until the password change is reflected in LDAP.  By default, msktutil exits once a password update is
 successful and the new keytab is written.  However, due to replication delays, LDAP queries might still
@@ -451,6 +455,9 @@ Enables the account to be trusted for delegation (see --delegation).
 .TP
 MSKTUTIL_NO_PAC
 Specifies that service tickets for this account should not contain a PAC (see --no-pac).
+.TP
+MSKTUTIL_SAMBA_CMD
+Specifies the command to be used to locally set the machine account password in Samba's  secrets.tdb.
 .SH AUTHORS
 (C) 2004-2006 Dan Perry <dperry at pppl.gov>
 .PP

--- a/msktutil.h
+++ b/msktutil.h
@@ -122,6 +122,8 @@
 #define KVNO_FAILURE                    -1
 #define KVNO_WIN_2000                   0
 
+#define DEFAULT_SAMBA_CMD "net changesecretpw -f -i"
+
 /* Ways we can authenticate */
 enum auth_types {
     AUTH_NONE = 0,
@@ -188,6 +190,7 @@ public:
     bool no_canonical_name;
     bool server_behind_nat;
     bool set_samba_secret;
+    std::string samba_cmd;
     bool check_replication;
     bool dont_change_password;
 

--- a/samba-password-command.sh
+++ b/samba-password-command.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Workaround for https://github.com/msktutil/msktutil/issues/124 
+#
+# for Samba 4.7 (RHEL/CentOS 7)
+#
+# 22.09.2018 jaroslaw.polok@gmail.com
+#
+# Usage:
+#
+#   msktutil --set-samba-secret --use-samba-cmd /path/to/this/script
+#
+#   MSKTUTIL_SAMBA_CMD=/pat/tp/this/script msktutil --set-samba-secret
+#
+
+#
+# Samba workgroup (UPPERCASE)
+# WORKGROUP="MYWORKGROUP"
+#
+
+WORKGROUP=""
+
+#
+# Active Directory Domain Controller to query for Domain SID
+# DCHOST="mydc.my.domain"
+#
+
+DCHOST=""
+
+#
+# Samba utilities used.
+# (RHEL/CentOS 7: tdb-tools and samba-common-tools rpms)
+#
+
+TDBTOOL="/usr/bin/tdbtool"
+NET="/usr/bin/net"
+TESTPARM="/usr/bin/testparm"
+
+samba_msg() {
+echo "$0: Error: "
+echo "       Adjust your SAMBA configuration first in /etc/samba/smb.conf"
+echo "       [global] section must contain at least following directives:"
+echo "       security  = ADS"
+echo "       workgroup = $WORKGROUP" 
+}
+
+[ "$UID" -ne 0 ] && echo "$0 must be run as root." && exit 1
+
+[ "x$WORKGROUP" == "x" ] && echo "$0: Error WORKGROUP not set" && exit 1
+
+[ "x$DCHOST" == "x" ] && echo "$0: Error DCHOST not set" && exit 1
+
+if [ ! -x $TDBTOOL ] || [ ! -x $NET ]; then
+   echo "Error: tdbtool and net SAMBA utilities are not installed."
+   exit 1
+fi
+
+$TESTPARM -l -s --parameter-name workgroup 2>/dev/null | /usr/bin/grep -q -P "^$WORKGROUP"
+
+[ $? -ne 0 ] && samba_msg && exit 1
+
+$TESTPARM -l -s --parameter-name security 2>/dev/null | /usr/bin/grep -q -P "^ADS$"
+
+[ $? -ne 0 ] && samba_msg && exit 1
+
+$NET -k -P rpc getsid -S $DCHOST
+
+[ $? -ne 0 ] && echo "$0: Error running $NET getsid" && exit 1
+
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_LAST_CHANGE_TIME/$WORKGROUP 0000 2>/dev/null 1>/dev/null
+
+[ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (1)" && exit 1
+
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD.PREV/$WORKGROUP none 2>/dev/null 1>/dev/null
+
+[ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (2)" && exit 1
+
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD/$WORKGROUP none 2>/dev/null 1>/dev/null
+
+[ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (3)" && exit 1
+
+exec $NET changesecretpw -f -i
+
+
+
+

--- a/samba-password-command.sh
+++ b/samba-password-command.sh
@@ -55,11 +55,11 @@ if [ ! -x $TDBTOOL ] || [ ! -x $NET ]; then
    exit 1
 fi
 
-$TESTPARM -l -s --parameter-name workgroup 2>/dev/null | /usr/bin/grep -q -P "^$WORKGROUP"
+$TESTPARM -l -s --parameter-name workgroup 2>/dev/null | /usr/bin/grep -q -x "$WORKGROUP"
 
 [ $? -ne 0 ] && samba_msg && exit 1
 
-$TESTPARM -l -s --parameter-name security 2>/dev/null | /usr/bin/grep -q -P "^ADS$"
+$TESTPARM -l -s --parameter-name security 2>/dev/null | /usr/bin/grep -q -x "ADS"
 
 [ $? -ne 0 ] && samba_msg && exit 1
 
@@ -67,15 +67,15 @@ $NET -k -P rpc getsid -S $DCHOST
 
 [ $? -ne 0 ] && echo "$0: Error running $NET getsid" && exit 1
 
-$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_LAST_CHANGE_TIME/$WORKGROUP 0000 2>/dev/null 1>/dev/null
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_LAST_CHANGE_TIME/"$WORKGROUP" 0000 2>/dev/null 1>/dev/null
 
 [ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (1)" && exit 1
 
-$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD.PREV/$WORKGROUP none 2>/dev/null 1>/dev/null
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD.PREV/"$WORKGROUP" none 2>/dev/null 1>/dev/null
 
 [ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (2)" && exit 1
 
-$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD/$WORKGROUP none 2>/dev/null 1>/dev/null
+$TDBTOOL /var/lib/samba/private/secrets.tdb store SECRETS/MACHINE_PASSWORD/"$WORKGROUP" none 2>/dev/null 1>/dev/null
 
 [ $? -ne 0 ] && echo "$0: Error running $TDBTOOL (3)" && exit 1
 


### PR DESCRIPTION
Following the discussion at: https://github.com/msktutil/msktutil/issues/124 here is proposed implementation of using external command instead of 'net' to set samba machine password in secrets.tdb
This PR also includes an example samba 4.7 workaround script which can be used as such command.

