### PR TITLE
Permit specifying candidate SASL mechanisms for the LDAP bind.

### DIFF
--- a/ldapconnection.cpp
+++ b/ldapconnection.cpp
@@ -55,6 +55,7 @@ static int sasl_interact(ATTRUNUSED LDAP *ld, ATTRUNUSED unsigned flags,
 }
 
 LDAPConnection::LDAPConnection(const std::string &server,
+        const std::string &sasl_mechanisms,
         bool no_reverse_lookups) :
         m_ldap()
 {
@@ -105,9 +106,9 @@ LDAPConnection::LDAPConnection(const std::string &server,
             "reverse lookups");
 #endif
 
-    VERBOSEldap("calling ldap_sasl_interactive_bind_s");
+    VERBOSEldap("calling ldap_sasl_interactive_bind_s with mechs = %s", sasl_mechanisms.c_str());
 
-    ret = ldap_sasl_interactive_bind_s(m_ldap, NULL, "GSSAPI", NULL, NULL,
+    ret = ldap_sasl_interactive_bind_s(m_ldap, NULL, sasl_mechanisms.c_str(), NULL, NULL,
 #ifdef LDAP_SASL_QUIET
             g_verbose ? 0 : LDAP_SASL_QUIET,
 #else

--- a/ldapconnection.h
+++ b/ldapconnection.h
@@ -60,7 +60,7 @@ private:
 
 
 public:
-    LDAPConnection(const std::string &server, bool no_reverse_lookups = false);
+    LDAPConnection(const std::string &server, const std::string &sasl_mechanisms, bool no_reverse_lookups = false);
     void set_option(int option, const void *invalue);
     void get_option(int option, void *outvalue);
 

--- a/msktutil.M
+++ b/msktutil.M
@@ -185,6 +185,12 @@ credentials (description, userAccountControl, userPrincipalName, in a default AD
 .TP
 --auto-update-interval <days>
 Number of <days> when REPLACE_PROGNAME auto-update will change the account password. Defaults to 30 days.
+.TP
+-m, --sasl-mechanisms <mechanisms list>
+A space-separated list of candidate SASL mechanisms to use when performing the LDAP bind.  The first mechanism in
+the list that is supported by both the client (the host running REPLACE_PROGNAME) and the server (Active Directory)
+will be used. If providing more than one candidate mechanism, make sure to quote the list to protect the whitespace
+from the shell.  Default: "GSS-SPNEGO GSSAPI".
 .SS OBJECT TYPE/ATTRIBUTE-SETTING OPTIONS
 .TP
 --use-service-account

--- a/msktutil.h
+++ b/msktutil.h
@@ -124,6 +124,9 @@
 
 #define DEFAULT_SAMBA_CMD "net changesecretpw -f -i"
 
+/* Default candidate SASL mechanisms */
+#define DEFAULT_SASL_MECHANISMS "GSS-SPNEGO GSSAPI"
+
 /* Ways we can authenticate */
 enum auth_types {
     AUTH_NONE = 0,
@@ -211,6 +214,7 @@ public:
     bool allow_weak_crypto;
     bool password_expired;
     int auto_update_interval;
+    std::string sasl_mechanisms;
     krb5_kvno kvno;
     int cleanup_days;
     int cleanup_enctype;


### PR DESCRIPTION
There are two motivations for this:

1. There is good reason to change the preferred mechanism from GSSAPI to GSS-SPNEGO. (See below.)
2. Allowing the candidate mechanism list to be overridden on the command line permits both easily restoring the old behavior of using GSSAPI, and potentially using newer mechanisms in the future without needing to rebuild msktutil.

Previously, the `ldap_sasl_interactive_bind_s()` call hardcoded the GSSAPI mechanism. While this mechanism should be supported by any modern Active Directory Domain Controller, most DCs also support the newer GSS-SPNEGO mechanism.

As of August 2019, Microsoft recommends enabling LDAP channel binding and LDAP signing:

https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/ldap-channel-binding-and-ldap-signing-requirements-march-2020/ba-p/921536

Both the GSSAPI and GSS-SPNEGO mechanisms authenticate and seal (encrypt) the communication with the DC, and will work if the DC is configured to require LDAP channel binding and LDAP signing. (A sealed message cannot be modified in transit and is thus immune to man-in-the-middle attacks.)

However, on DCs without KB4559003 applied, using the GSSAPI mechanism will generate event ID 2889 in the event log:

> The following client performed a SASL (Negotiate/Kerberos/NTLM/Digest) LDAP bind without requesting signing (integrity verification), or performed a simple bind over a cleartext (non-SSL/TLS-encrypted) LDAP connection. Client IP address: ‘Value’ Identity the client attempted to authenticate as: ‘Value’

In KB4559003:

https://support.microsoft.com/en-us/help/4559003/windows-10-update-kb4559003

…Microsoft quieted the event log generation when GSSAPI is used:

> Addresses an issue that incorrectly reports Lightweight Directory Access Protocol (LDAP) sessions as unsecure sessions in Event ID 2889. This occurs when the LDAP session is authenticated and sealed with a Simple Authentication and Security Layer (SASL) method.”

Nonetheless, if GSS-SPNEGO is available, using it instead of GSSAPI will ensure both LDAP signing and sealing, and avoid the bogus event log generation, even on DCs without KB4559003 applied. For that reason, we default to `GSS-SPNEGO GSSAPI` for the SASL candidate mechanisms list. This will cause GSS-SPNEGO to be used if both the client’s SASL library supports it and the DC supports it. Otherwise, GSSAPI will be used.

Again, as per above, the `--sasl-mechanisms` option permits restoring the old behavior of using GSSAPI.

When LDAP debugging is enabled, msktutil will show the candidate SASL mechanisms string that it passes to `ldap_sasl_interactive_bind_s()`.