### PR TITLE
Consistent creation of SPNs

### DIFF
--- a/msktkrb5.cpp
+++ b/msktkrb5.cpp
@@ -312,10 +312,6 @@ void update_keytab(msktutil_flags *flags)
     if (!flags->userPrincipalName.empty()) {
         add_principal_keytab(flags->userPrincipalName, flags);
     }
-    /* add host/<short_hostname> */
-    if (!flags->use_service_account) {
-        add_principal_keytab("host/" + get_short_hostname(flags), flags);
-    }
     for (size_t i = 0; i < flags->ad_principals.size(); ++i) {
         if ((flags->userPrincipalName.empty()) ||
             flags->userPrincipalName.compare(flags->ad_principals[i]) != 0) {

--- a/msktutil.M
+++ b/msktutil.M
@@ -265,7 +265,9 @@ administrator credentials.
 -s, --service <principal>
 Specifies a service principal to add to the account (and thus keytab, if appropriate).  The service is of
 the form <service>/<hostname>.  If the hostname is omitted, assumes current hostname.  May be specified
-multiple times.
+multiple times. When creating machine accounts without --service ... the default service principals are
+host/long_hostname and host/short_hostname. When creating service accounts without --service ...
+no service principals are added.
 .TP
 --remove-service <principal>
 Specifies a service principal to remove from the account (and keytab if appropriate).

--- a/msktutil.M
+++ b/msktutil.M
@@ -265,9 +265,9 @@ administrator credentials.
 -s, --service <principal>
 Specifies a service principal to add to the account (and thus keytab, if appropriate).  The service is of
 the form <service>/<hostname>.  If the hostname is omitted, assumes current hostname.  May be specified
-multiple times. When creating machine accounts without --service ... the default service principals are
-host/long_hostname and host/short_hostname. When creating service accounts without --service ...
-no service principals are added.
+multiple times. When creating machine accounts, entries for the host service are created by default,
+unless --service is given. Unqualified service names (without a '/' component) are qualified with
+the full and the short hostnames, eg. host/hostname.example.com and host/hostname.
 .TP
 --remove-service <principal>
 Specifies a service principal to remove from the account (and keytab if appropriate).

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -843,7 +843,7 @@ int main(int argc, char *argv [])
         if (!strcmp(argv[i], "--service") || !strcmp(argv[i], "-s")) {
             if (++i < argc) {
                 exec->add_principals.push_back(argv[i]);
-               flags->add_only_default_spns = false;
+                flags->add_only_default_spns = false;
             } else {
                 fprintf(stderr,
                         "Error: No service principal given after '%s'\n",

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -282,9 +282,9 @@ int finalize_exec(msktutil_exec *exec, msktutil_flags *flags)
     }
     VERBOSE("SAM Account Name is: %s", flags->sAMAccountName.c_str());
 
-    if (exec->mode == MODE_CREATE && !flags->use_service_account && flags->add_only_default_spns) {
-      exec->add_principals.push_back("host/" + flags->hostname);
-      exec->add_principals.push_back("host/" + get_short_hostname(flags));
+    if (exec->mode == MODE_CREATE && !flags->use_service_account) {
+      exec->add_principals.push_back("host");
+       exec->add_principals.push_back("host/" + get_short_hostname(flags));
     }
 
     /* Qualify entries in the principals list */
@@ -843,7 +843,6 @@ int main(int argc, char *argv [])
         if (!strcmp(argv[i], "--service") || !strcmp(argv[i], "-s")) {
             if (++i < argc) {
                 exec->add_principals.push_back(argv[i]);
-                flags->add_only_default_spns = false;
             } else {
                 fprintf(stderr,
                         "Error: No service principal given after '%s'\n",
@@ -1363,7 +1362,6 @@ msktutil_flags::msktutil_flags() :
     samba_cmd(DEFAULT_SAMBA_CMD),
     check_replication(false),
     dont_change_password(false),
-    add_only_default_spns(true),
     dont_expire_password(VALUE_IGNORE),
     dont_update_dnshostname(VALUE_OFF),
     disable_account(VALUE_IGNORE),

--- a/msktutil.h
+++ b/msktutil.h
@@ -196,6 +196,7 @@ public:
     std::string samba_cmd;
     bool check_replication;
     bool dont_change_password;
+    bool add_only_default_spns;
 
     msktutil_val dont_expire_password;
     msktutil_val dont_update_dnshostname;

--- a/msktutil.h
+++ b/msktutil.h
@@ -196,7 +196,6 @@ public:
     std::string samba_cmd;
     bool check_replication;
     bool dont_change_password;
-    bool add_only_default_spns;
 
     msktutil_val dont_expire_password;
     msktutil_val dont_update_dnshostname;


### PR DESCRIPTION
msktutil --create ... without --service and without --use-service-account
should create a machine account with the following SPNs:

  host/FQDN
  host/shortname

This is what `setspn -R` is doing and what other "domain join" tools are doing.

Keytab entries are already created that way

With --service ... only the specified SPNs will be registered.