### PR TITLE
Clean up MS Kerberos encryption types (#157)

### DIFF
--- a/msktldap.cpp
+++ b/msktldap.cpp
@@ -489,8 +489,7 @@ void ldap_check_account_strings(msktutil_flags *flags)
     ldap_set_supportedEncryptionTypes(dn, flags);
 
     msktutil_val des_only;
-    if (flags->supportedEncryptionTypes == (MS_KERB_ENCTYPE_DES_CBC_CRC |
-                                            MS_KERB_ENCTYPE_DES_CBC_MD5)) {
+    if (flags->supportedEncryptionTypes == MS_KERB_DES_ENCTYPES) {
         des_only = VALUE_ON;
     } else {
         des_only = VALUE_OFF;
@@ -501,10 +500,8 @@ void ldap_check_account_strings(msktutil_flags *flags)
      * VALUE_OFF. In that case, reset ad_supportedEncryptionTypes
      * according to the DES flag, in case we changed it. */
     if (flags->ad_enctypes == VALUE_OFF) {
-        flags->ad_supportedEncryptionTypes =
-            MS_KERB_ENCTYPE_DES_CBC_CRC |
-            MS_KERB_ENCTYPE_DES_CBC_MD5;
-        if (! (flags->ad_userAccountControl & UF_USE_DES_KEY_ONLY)) {
+        flags->ad_supportedEncryptionTypes = MS_KERB_DES_ENCTYPES;
+        if (!(flags->ad_userAccountControl & UF_USE_DES_KEY_ONLY)) {
             flags->ad_supportedEncryptionTypes |= MS_KERB_ENCTYPE_RC4_HMAC_MD5;
         }
     }
@@ -604,10 +601,8 @@ bool ldap_check_account(msktutil_flags *flags)
                 flags->ad_supportedEncryptionTypes);
     } else {
         /* Not in current LDAP entry set defaults */
-        flags->ad_supportedEncryptionTypes =
-            MS_KERB_ENCTYPE_DES_CBC_CRC |
-            MS_KERB_ENCTYPE_DES_CBC_MD5;
-        if (! (flags->ad_userAccountControl & UF_USE_DES_KEY_ONLY)) {
+        flags->ad_supportedEncryptionTypes = MS_KERB_DES_ENCTYPES;
+        if (!(flags->ad_userAccountControl & UF_USE_DES_KEY_ONLY)) {
             flags->ad_supportedEncryptionTypes |= MS_KERB_ENCTYPE_RC4_HMAC_MD5;
         }
         flags->ad_enctypes = VALUE_OFF; /* this is the assumed default */
@@ -712,8 +707,7 @@ void ldap_create_account(msktutil_flags *flags)
 
     /* Defaults, will attempt to reset later */
     flags->ad_supportedEncryptionTypes =
-        MS_KERB_ENCTYPE_DES_CBC_CRC |
-        MS_KERB_ENCTYPE_DES_CBC_MD5 |
+        MS_KERB_DES_ENCTYPES |
         MS_KERB_ENCTYPE_RC4_HMAC_MD5;
     flags->ad_enctypes = VALUE_OFF;
     flags->ad_userAccountControl = userAcctFlags;

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -1272,17 +1272,11 @@ int main(int argc, char *argv [])
     }
 
     if (flags->enctypes == VALUE_ON) {
-        unsigned known= MS_KERB_ENCTYPE_DES_CBC_CRC |
-                        MS_KERB_ENCTYPE_DES_CBC_MD5 |
-                        MS_KERB_ENCTYPE_RC4_HMAC_MD5 |
-                        MS_KERB_ENCTYPE_AES128_CTC_HMAC_SHA1_96 |
-                        MS_KERB_ENCTYPE_AES256_CTS_HMAC_SHA1_96;
-
-        if ((flags->supportedEncryptionTypes|known) != known) {
+        if ((flags->supportedEncryptionTypes | ALL_MS_KERB_ENCTYPES) != ALL_MS_KERB_ENCTYPES) {
             fprintf(stderr,
                     "Error: Unsupported --enctypes must be integer that "
                     "fits mask=0x%x\n",
-                    known
+                    ALL_MS_KERB_ENCTYPES
                 );
             goto error;
         }
@@ -1368,9 +1362,7 @@ msktutil_flags::msktutil_flags() :
     ad_supportedEncryptionTypes(0),
     enctypes(VALUE_IGNORE),
     /* default values we *want* to support */
-    supportedEncryptionTypes(MS_KERB_ENCTYPE_RC4_HMAC_MD5 |
-                             MS_KERB_ENCTYPE_AES128_CTC_HMAC_SHA1_96 |
-                             MS_KERB_ENCTYPE_AES256_CTS_HMAC_SHA1_96),
+    supportedEncryptionTypes(DEFAULT_MS_KERB_ENCTYPES),
     auth_type(0),
     user_creds_only(false),
     use_service_account(false),

--- a/msktutil.h
+++ b/msktutil.h
@@ -99,7 +99,7 @@
 #define UF_USE_DES_KEY_ONLY             0x00200000
 #define UF_NO_AUTH_DATA_REQUIRED        0x02000000
 
-/* for msDs-supportedEncryptionTypes  bit defines */
+/* for msDs-supportedEncryptionTypes bit defines */
 #define MS_KERB_ENCTYPE_DES_CBC_CRC             0x01
 #define MS_KERB_ENCTYPE_DES_CBC_MD5             0x02
 #define MS_KERB_ENCTYPE_RC4_HMAC_MD5            0x04
@@ -116,6 +116,21 @@
 #else
 #define MS_KERB_ENCTYPE_AES256_CTS_HMAC_SHA1_96 0
 #endif
+
+#define MS_KERB_DES_ENCTYPES \
+    ( MS_KERB_ENCTYPE_DES_CBC_CRC | \
+      MS_KERB_ENCTYPE_DES_CBC_MD5 )
+
+#define DEFAULT_MS_KERB_ENCTYPES \
+    ( MS_KERB_ENCTYPE_RC4_HMAC_MD5 | \
+      MS_KERB_ENCTYPE_AES128_CTC_HMAC_SHA1_96 | \
+      MS_KERB_ENCTYPE_AES256_CTS_HMAC_SHA1_96 )
+
+#define ALL_MS_KERB_ENCTYPES \
+    ( MS_KERB_DES_ENCTYPES | \
+      MS_KERB_ENCTYPE_RC4_HMAC_MD5 | \
+      MS_KERB_ENCTYPE_AES128_CTC_HMAC_SHA1_96 | \
+      MS_KERB_ENCTYPE_AES256_CTS_HMAC_SHA1_96 )
 
 /* Some KVNO Constansts */
 #define KVNO_FAILURE                    -1


### PR DESCRIPTION
* Move all default values to a compile time macro: DEFAULT_MS_KERB_ENCTYPES
  and use macro throughout
* Introduce macro ALL_MS_KERB_ENCTYPES for all supported encryption types
* Introduce macro MS_KERB_DES_ENCTYPES for all DES-based encryption types
* Invert logic to set DES only if it requested via command line