### PR TITLE
Print effectively supported encryption types when constructing a keytab

### DIFF
--- a/msktkrb5.cpp
+++ b/msktkrb5.cpp
@@ -374,6 +374,7 @@ static void prune_keytab(KRB5Keytab& keytab, KRB5Principal &principal, krb5_time
 void add_principal_keytab(const std::string &principal, msktutil_flags *flags)
 {
     VERBOSE("Adding principal to keytab: %s", principal.c_str());
+    VERBOSE("Using supportedEncryptionTypes: %d", flags->ad_supportedEncryptionTypes);
     KRB5Keytab keytab(flags->keytab_writename);
 
     std::string principal_string = "";


### PR DESCRIPTION
This closes #158 and closes #160