### PR TITLE
Properly use krb5_enctype in vectors

### DIFF
--- a/msktkrb5.cpp
+++ b/msktkrb5.cpp
@@ -394,7 +394,7 @@ void add_principal_keytab(const std::string &principal, msktutil_flags *flags)
 
     prune_keytab(keytab, princ, min_keep_timestamp);
 
-    std::vector<uint32_t> enc_types;
+    std::vector<int32_t> enc_types;
     if (flags->ad_supportedEncryptionTypes & MS_KERB_ENCTYPE_DES_CBC_CRC) {
         enc_types.push_back(ENCTYPE_DES_CBC_CRC);
     }


### PR DESCRIPTION
This compiles for me on:
* FreeBSD: Clang, GCC with Heimdal, MIT Kerberos
* HP-UX: aCC and MIT Kerberos