### PR TITLE
move ldap connection out of global flags

### DIFF
--- a/msktkrb5.cpp
+++ b/msktkrb5.cpp
@@ -126,7 +126,7 @@ std::string get_salt(msktutil_flags *flags)
 }
 
 
-int flush_keytab(msktutil_flags *flags)
+int flush_keytab(LDAPConnection *ldap, msktutil_flags *flags)
 {
     VERBOSE("Flushing the keytab");
     KRB5Keytab keytab(flags->keytab_writename);
@@ -155,7 +155,7 @@ int flush_keytab(msktutil_flags *flags)
         keytab.removeEntry(principal, it->kvno(), it->enctype());
     }
 
-    return ldap_flush_principals(flags);
+    return ldap_flush_principals(ldap, flags);
 }
 
 

--- a/msktpass.cpp
+++ b/msktpass.cpp
@@ -145,7 +145,6 @@ int set_password(msktutil_flags *flags)
     krb5_data resp_code_string;
     krb5_data resp_string;
     int response = 0;
-    std::string old_pwdLastSet;
 
     /* Zero out these data structures, because we attempt to free them
      * below, and sometimes, upon error conditions, the called API
@@ -166,7 +165,6 @@ int set_password(msktutil_flags *flags)
         KRB5CCache ccache(KRB5CCache::defaultName());
         KRB5Principal principal(flags->sAMAccountName);
 
-        old_pwdLastSet = ldap_get_pwdLastSet(flags);
         ret = krb5_set_password_using_ccache(g_context,
                                              ccache.get(),
                                              const_cast<char*>(flags->password.c_str()),
@@ -252,10 +250,6 @@ int set_password(msktutil_flags *flags)
             creds.move_from(local_creds);
         } else /* shouldn't happen */
             throw Exception("Error: unknown auth_type.");
-
-        if (flags->auth_type != AUTH_FROM_SUPPLIED_EXPIRED_PASSWORD) {
-            old_pwdLastSet = ldap_get_pwdLastSet(flags);
-        }
 
         ret = krb5_change_password(g_context,
                                    creds.get(),

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -572,9 +572,15 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
     }
     LDAPConnection *ldap = finalize_exec(exec, flags);
 
-    if (ret) {
+    if (exec->mode == MODE_CLEANUP) {
+        fprintf(stdout, "Cleaning keytab %s\n",
+                flags->keytab_writename.c_str());
+        cleanup_keytab(flags);
+        return 0;
+    }
+    if (ldap == NULL) {
         fprintf(stderr, "Error: finalize_exec failed\n");
-        exit(ret);
+        exit(1);
     }
     if (exec->mode == MODE_FLUSH) {
         if (flags->use_service_account) {
@@ -735,13 +741,6 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
         delete ldap;
         ldap = NULL;
         return ret;
-    } else if (exec->mode == MODE_CLEANUP) {
-        fprintf(stdout, "Cleaning keytab %s\n",
-                flags->keytab_writename.c_str());
-        cleanup_keytab(flags);
-        delete ldap;
-        ldap = NULL;
-        return 0;
     }
     delete ldap;
     ldap = NULL;

--- a/msktutil.h
+++ b/msktutil.h
@@ -270,39 +270,38 @@ public:
 };
 
 /* Prototypes */
-extern std::string create_default_machine_password(const std::string &sAMAccountName);
-extern void ldap_cleanup(msktutil_flags *);
-extern void init_password(msktutil_flags *);
-extern std::string get_default_hostname(bool no_canonical_name = false);
-extern void get_default_keytab(msktutil_flags *);
-extern std::string get_salt(msktutil_flags *);
-extern void get_default_ou(msktutil_flags *);
-
-extern void ldap_get_base_dn(msktutil_flags *);
-extern std::string complete_hostname(const std::string &,
-                                     bool no_canonical_name = false);
-extern std::string get_default_samaccountname(msktutil_flags *);
-extern std::string get_short_hostname(msktutil_flags *);
-extern int flush_keytab(msktutil_flags *);
-extern void cleanup_keytab(msktutil_flags *);
-extern void update_keytab(msktutil_flags *);
-extern void add_keytab_entries(msktutil_flags *);
-extern void remove_keytab_entries(msktutil_flags *,std::vector<std::string>);
-extern void add_principal_keytab(const std::string &, msktutil_flags *);
-extern int ldap_flush_principals(msktutil_flags *);
-extern int set_password(msktutil_flags *);
-extern krb5_kvno ldap_get_kvno(msktutil_flags *);
-extern std::string ldap_get_pwdLastSet(msktutil_flags *);
-extern std::vector<std::string> ldap_list_principals(msktutil_flags *);
-extern int ldap_add_principal(const std::string &, msktutil_flags *);
-int ldap_remove_principal(const std::string &principal, msktutil_flags *flags);
-extern std::string get_dc_host(const std::string &realm_name, const std::string &site_name,
+std::string create_default_machine_password(const std::string &sAMAccountName);
+void init_password(msktutil_flags *);
+std::string get_default_hostname(bool no_canonical_name = false);
+void get_default_keytab(msktutil_flags *);
+std::string get_salt(msktutil_flags *);
+void get_default_ou(LDAPConnection *, msktutil_flags *);
+void ldap_get_base_dn(msktutil_flags *);
+std::string complete_hostname(const std::string &,
+                              bool no_canonical_name = false);
+std::string get_default_samaccountname(msktutil_flags *);
+std::string get_short_hostname(msktutil_flags *);
+int flush_keytab(LDAPConnection *ldap, msktutil_flags *);
+void cleanup_keytab(msktutil_flags *);
+void update_keytab(msktutil_flags *);
+void add_keytab_entries(msktutil_flags *);
+void remove_keytab_entries(msktutil_flags *,std::vector<std::string>);
+void add_principal_keytab(const std::string &, msktutil_flags *);
+int ldap_flush_principals(LDAPConnection *, msktutil_flags *);
+int set_password(msktutil_flags *);
+krb5_kvno ldap_get_kvno(LDAPConnection *, msktutil_flags *);
+std::string ldap_get_pwdLastSet(LDAPConnection *, msktutil_flags *);
+bool ldap_check_account(LDAPConnection *, msktutil_flags *);
+void ldap_create_account(LDAPConnection *, msktutil_flags *);
+void remove_ccache();
+std::vector<std::string> ldap_list_principals(msktutil_flags *);
+int ldap_add_principal(LDAPConnection *, const std::string &, msktutil_flags *);
+int ldap_remove_principal(LDAPConnection *, const std::string &principal, msktutil_flags *flags);
+std::string get_dc_host(const std::string &realm_name, const std::string &site_name,
                                const bool);
-extern bool ldap_check_account(msktutil_flags *);
-extern void ldap_create_account(msktutil_flags *);
-extern void create_fake_krb5_conf(msktutil_flags *);
-extern void remove_fake_krb5_conf();
-extern void remove_ccache();
+
+void create_fake_krb5_conf(msktutil_flags *);
+void remove_fake_krb5_conf();
 int find_working_creds(msktutil_flags *flags);
 bool get_creds(msktutil_flags *flags);
 int generate_new_password(msktutil_flags *flags);

--- a/msktutil.h
+++ b/msktutil.h
@@ -197,7 +197,6 @@ public:
     std::string userPrincipalName;
     std::string old_account_password;
     std::string site;
-    LDAPConnection* ldap;
     std::string ad_computerDn;
     std::string ad_dnsHostName;
     std::vector<std::string> ad_principals;


### PR DESCRIPTION
Hi @mproehl , @dkobras . I looked into how the overall code quality can be improved.

One of the misfeatures of msktutil is misusing msktutil_flags for global variables. It makes  unobvious who is in charge of initializing and updating.
Refactored all code to explicitly have it as argument.

While doing that I uncovered a bug: set_password used the ldap connection for determine the password was last set. It was called without initializing ldapConnection first. However the date the password last set was actually not used at all. So the fix is easy by removing the dependency of set_password on a ldapConnection.

Could you please check if I accidentely broke something?
