### PR TITLE
addEntry: try to use KDC-supplied salt info

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,7 +306,7 @@ fi
 fi
 
 # Check for functions
-AC_CHECK_FUNCS(vasprintf vsnprintf setenv strtoll ldap_initialize)
+AC_CHECK_FUNCS(vasprintf vsnprintf setenv strtoll ldap_initialize krb5_get_etype_info)
 
 # Check that the AES enctypes are found
 AC_CHECK_DECLS([ENCTYPE_AES256_CTS_HMAC_SHA1_96, ENCTYPE_AES128_CTS_HMAC_SHA1_96], [], [], [[#include <krb5.h>]])


### PR DESCRIPTION
We need to determine salt values based on the heuristics described in
windows-salt.txt. This may fail in some corner cases, and might break
completely in future versions of Active Directory, as the KDC is not
bound to follow a certain salt scheme. Recent MIT Kerberos (since
v1.17) allows to query the KDC for the proper salt value. We try to
make use of the interface if available, and fall back to the heuristics
in case of any failure.

Previously, the following test cases yielded invalid keytab entries
because the heurisic would derive an incorrect salt, based on the
sAMAccountName rather than the UPN. With this changeset in place,
a working keytab is created:

% kinit Administrator
% msktutil create --use-service-account \
                  --service HTTP/foo \
                  --account-name foo \
                  --upn HTTP/foo \
                  --keytab /tmp/foo.keytab
% kvno -k /tmp/foo.keytab HTTP/foo
HTTP/bar@ADS.EXAMPLE.COM: kvno = 1, keytab entry valid

Closes: #135 #156