### PR TITLE
Fix ns_initparse() detection in libc for config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,8 @@ AC_SEARCH_LIBS([ns_initparse], [resolv], AC_DEFINE(HAVE_NS_INITPARSE, 1, [define
 		]],[[
 	ns_initparse(0, 0, 0);
 		]])],
-		AC_MSG_RESULT([yes]), [
+		[AC_DEFINE(HAVE_NS_INITPARSE,1)
+		AC_MSG_RESULT([yes])], [
 		# now try libresolv again
 		AC_MSG_RESULT([no])
 		saved_LIBS="$LIBS"


### PR DESCRIPTION
If the ns_initparse() function is contained in libc, like on FreeBSD the marco
for config.h was not set, therefore SRV RR queries were not available on
FreeBSD.