### PR TITLE
Add missing dependency to fix fedora auto-build

### DIFF
--- a/.github/workflows/msktutil.yml
+++ b/.github/workflows/msktutil.yml
@@ -86,7 +86,15 @@ jobs:
             apt-get install -q -y \
               libldap2-dev libkrb5-dev libsasl2-dev
             ;;
-          fedora*|centos:8)
+          fedora*)
+            # basic packages
+            dnf -y install \
+              autoconf automake gcc-c++ libtool make pkgconfig which redhat-rpm-config
+            # install dependencies
+            dnf -y install \
+              cyrus-sasl-devel krb5-devel openldap-devel
+            ;;
+          centos:8)
             # basic packages
             dnf -y install \
               autoconf automake gcc-c++ libtool make pkgconfig which


### PR DESCRIPTION
On latest Fedora, some tools like libtool and krb5-config add a reference to
/usr/lib/rpm/redhat/redhat-annobin-cc1 to the generated compiler or linker
flags. Install package redhat-rpm-config to make sure this file is available
in our build environment.