### PR TITLE
Update FreeBSD auto-build action to latest version

### DIFF
--- a/.github/workflows/msktutil-freebsd.yml
+++ b/.github/workflows/msktutil-freebsd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     name: Build on FreeBSD
     strategy:
       fail-fast: false
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build msktutil with ${{ matrix.cfg.cc-version }}
       id: build
-      uses: vmactions/freebsd-vm@main
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         mem: 2048
         usesh: true

--- a/.github/workflows/msktutil-freebsd.yml
+++ b/.github/workflows/msktutil-freebsd.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           freebsd-version
           # basic dependencies
-          pkg install -y autoconf cyrus-sasl-gssapi gmake openldap-sasl-client
+          pkg install -y autoconf cyrus-sasl-gssapi gmake openldap24-client
           case "${{ matrix.cfg.cc-version }}" in
             gcc)
               pkg install -y gcc


### PR DESCRIPTION
Use fixed MacOS version dependency as per docs for latest version v0.1.5 of
freebsd-vm action (cf. also vmactions/freebsd-vm#38).