### PR TITLE
Apply a consistent formatting of messages and principals (#74, #173)

### DIFF
--- a/krb5wrap.cpp
+++ b/krb5wrap.cpp
@@ -31,11 +31,11 @@
 #include "msktutil.h"
 
 void krb5_error_exit( const char *func, int err_code) {
-   v_error_exit("error_exit: krb func %s failed: (%s)", func, error_message(err_code));
+   v_error_exit("error_exit: krb5 function %s failed: %s", func, error_message(err_code));
 }
 
 void krb5_warn( const char *func, int err_code) {
-   fprintf( stderr, "Warning: krb func %s failed: (%s)", func, error_message(err_code));
+   fprintf( stderr, "Warning: krb5 function %s failed: %s", func, error_message(err_code));
 }
 
 #ifdef HEIMDAL
@@ -58,7 +58,7 @@ krb5_error_code krb5_free_keytab_entry_contents(krb5_context context,
 
 void
 initialize_g_context() {
-    VERBOSE("Creating Kerberos Context");
+    VERBOSE("Creating Kerberos context");
     krb5_error_code ret = krb5_init_context(&g_context);
     if (ret) {
         krb5_error_exit("krb5_init_context", ret);
@@ -67,7 +67,7 @@ initialize_g_context() {
 
 void
 destroy_g_context() {
-    VERBOSE("Destroying Kerberos Context");
+    VERBOSE("Destroying Kerberos context");
     krb5_free_context(g_context);
     g_context = 0;
 }
@@ -176,7 +176,7 @@ void KRB5Keytab::addEntry(const KRB5Principal &princ,
                                             &entry);
     if (ret) {
         if (errno != 0) {
-            fprintf(stderr,"Error: Keytab write error: %s!\n", strerror(errno));
+            fprintf(stderr,"Error: keytab write error: %s\n", strerror(errno));
         }
         throw KRB5Exception("krb5_kt_add_entry failed", ret);
     }
@@ -304,7 +304,7 @@ void KRB5Keytab::removeEntry(const KRB5Principal &princ,
                                                &entry);
     if (ret) {
         if (errno != 0) {
-            fprintf(stderr,"Error: Keytab write error: %s!\n", strerror(errno));
+            fprintf(stderr,"Error: keytab write error: %s\n", strerror(errno));
         }
         throw KRB5Exception("krb5_kt_remove_entry", ret);
     }

--- a/ldapconnection.cpp
+++ b/ldapconnection.cpp
@@ -62,10 +62,10 @@ LDAPConnection::LDAPConnection(const std::string &server,
     int ret = 0;
 #ifdef HAVE_LDAP_INITIALIZE
     std::string ldap_url = "ldap://" + server;
-    VERBOSEldap("calling ldap_initialize");
+    VERBOSEldap("Calling ldap_initialize");
     ret = ldap_initialize(&m_ldap, ldap_url.c_str());
 #else
-    VERBOSEldap("calling ldap_init");
+    VERBOSEldap("Calling ldap_init");
     m_ldap = ldap_init(server.c_str(), LDAP_PORT);
     if (m_ldap) {
         ret = LDAP_SUCCESS;
@@ -106,7 +106,7 @@ LDAPConnection::LDAPConnection(const std::string &server,
             "reverse lookups");
 #endif
 
-    VERBOSEldap("calling ldap_sasl_interactive_bind_s with mechs = %s", sasl_mechanisms.c_str());
+    VERBOSEldap("Calling ldap_sasl_interactive_bind_s with mechs: %s", sasl_mechanisms.c_str());
 
     ret = ldap_sasl_interactive_bind_s(m_ldap, NULL, sasl_mechanisms.c_str(), NULL, NULL,
 #ifdef LDAP_SASL_QUIET
@@ -213,7 +213,7 @@ LDAPConnection::search(const std::string &base_dn, int scope,
 {
     LDAPMessage * mesg;
 
-    VERBOSEldap("calling ldap_search_ext_s");
+    VERBOSEldap("Calling ldap_search_ext_s");
     VERBOSEldap("ldap_search_ext_s base context: %s", base_dn.c_str());
     VERBOSEldap("ldap_search_ext_s filter: %s", filter.c_str());
     int ret = ldap_search_ext_s(m_ldap, base_dn.c_str(), scope, filter.c_str(),
@@ -278,10 +278,10 @@ int LDAPConnection::modify_ext(const std::string &dn, const std::string& type,
     attr.mod_values = vals;
     mod_attrs[1] = NULL;
 
-    VERBOSEldap("calling ldap_modify_ext_s");
+    VERBOSEldap("Calling ldap_modify_ext_s");
     ret = ldap_modify_ext_s(m_ldap, dn.c_str(), mod_attrs, NULL, NULL);
     if (check && ret != LDAP_SUCCESS) {
-        VERBOSE("ldap_modify_ext_s failed (%s)", ldap_err2string(ret));
+        VERBOSE("ldap_modify_ext_s failed: %s", ldap_err2string(ret));
     }
     return ret;
 }

--- a/msktconf.cpp
+++ b/msktconf.cpp
@@ -151,7 +151,7 @@ void create_fake_krb5_conf(msktutil_flags *flags)
     }
 #endif
 
-    VERBOSE("Created a fake krb5.conf file: %s", g_config_filename.c_str());
+    VERBOSE("Created fake krb5.conf file: %s", g_config_filename.c_str());
 
     destroy_g_context();
     initialize_g_context();
@@ -202,7 +202,7 @@ bool try_machine_keytab_princ(msktutil_flags *flags,
                               const char *ccache_name)
 {
     try {
-        VERBOSE("Trying to authenticate for %s from local keytab",
+        VERBOSE("Trying to authenticate %s from local keytab",
                 principal_name.c_str());
         KRB5Keytab keytab(flags->keytab_readname);
         KRB5Principal principal(principal_name);
@@ -223,7 +223,7 @@ bool try_machine_keytab_princ(msktutil_flags *flags,
 bool try_machine_password(msktutil_flags *flags, const char *ccache_name)
 {
     try {
-        VERBOSE("Trying to authenticate for %s with password",
+        VERBOSE("Trying to authenticate %s with password",
                 flags->sAMAccountName.c_str());
         KRB5Principal principal(flags->sAMAccountName);
         KRB5Creds creds(principal,
@@ -246,7 +246,7 @@ bool try_machine_supplied_password(msktutil_flags *flags,
                                    const char *ccache_name)
 {
     try {
-        VERBOSE("Trying to authenticate for %s with supplied password",
+        VERBOSE("Trying to authenticate %s with supplied password",
                 flags->sAMAccountName.c_str());
         KRB5Principal principal(flags->sAMAccountName);
         KRB5Creds creds(principal, /*password:*/ flags->old_account_password);
@@ -301,7 +301,7 @@ bool try_user_creds()
         return true;
     } catch(KRB5Exception &e) {
         VERBOSE("%s", e.what());
-        VERBOSE("User ticket cache was not valid");
+        VERBOSE("Default ticket cache was not valid");
         return false;
     }
 }

--- a/msktname.cpp
+++ b/msktname.cpp
@@ -55,7 +55,7 @@ std::string complete_hostname(const std::string &hostname,
                                                   &temp_princ_raw);
     if (ret != 0) {
         fprintf(stderr,
-                "Warning: hostname canonicalization for %s failed (%s)\n",
+                "Warning: hostname canonicalization for %s failed: %s\n",
                 hostname.c_str(),
                 error_message(ret)
             );
@@ -161,7 +161,7 @@ bool DnsSrvHost::validate(bool nocanon, std::string service) {
     ret = getaddrinfo(srvname.c_str(), service.c_str(), &hints, &hostaddrinfo);
 
     if (ret != 0) {
-        VERBOSE("Error: gethostbyname failed for %s (%s)\n", srvname.c_str(),
+        VERBOSE("Error: gethostbyname failed for %s: %s\n", srvname.c_str(),
                 ret == EAI_SYSTEM ? strerror(errno) : gai_strerror(ret));
         if (hostaddrinfo) {
             freeaddrinfo(hostaddrinfo);
@@ -177,14 +177,14 @@ bool DnsSrvHost::validate(bool nocanon, std::string service) {
             close(sock);
         }
         if ((sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol)) == -1) {
-            VERBOSE("Failed to open socket (%s)", strerror(errno));
+            VERBOSE("Failed to open socket: %s", strerror(errno));
             continue;
         }
         if (connect(sock, (struct sockaddr *) ai->ai_addr, ai->ai_addrlen) == -1) {
             int err = errno;
             char addrstr[INET6_ADDRSTRLEN] = "";
             (void) inet_ntop(ai->ai_family, ai->ai_addr, addrstr, INET6_ADDRSTRLEN);
-            VERBOSE("LDAP connection to %s failed (%s)", addrstr, strerror(err));
+            VERBOSE("LDAP connection to %s failed: %s", addrstr, strerror(err));
             continue;
         }
 
@@ -204,7 +204,7 @@ bool DnsSrvHost::validate(bool nocanon, std::string service) {
             int err = errno;
             char addrstr[INET6_ADDRSTRLEN] = "";
             (void) inet_ntop(ai->ai_family, ai->ai_addr, addrstr, INET6_ADDRSTRLEN);
-            VERBOSE("Error: getnameinfo failed for %s (%s)\n", addrstr,
+            VERBOSE("Error: getnameinfo failed for %s: %s\n", addrstr,
                     ret == EAI_SYSTEM ? strerror(err) : gai_strerror(ret));
             continue;
         }
@@ -287,7 +287,7 @@ std::string get_dc_host(const std::string &realm_name, const std::string &site_n
 
     if (!site_name.empty()) {
         for (i = 0; i < (int)(sizeof(protocols) / sizeof(protocols[0])); i++) {
-            VERBOSE("Attempting to find site-specific Domain Controller to use via "
+            VERBOSE("Attempting to find site-specific domain controller to use via "
                             "DNS SRV record in domain %s for site %s and procotol %s",
                             realm_name.c_str(), site_name.c_str(), protocols[i].c_str());
             dcsrvs = DnsSrvQuery(site_name + "._sites.dc._msdcs." + realm_name, "kerberos", protocols[i]);
@@ -299,7 +299,7 @@ std::string get_dc_host(const std::string &realm_name, const std::string &site_n
 
     if (dcsrvs.empty()) {
         for (i = 0; i < (int)(sizeof(protocols) / sizeof(protocols[0])); i++) {
-            VERBOSE("Attempting to find Domain Controller to use via "
+            VERBOSE("Attempting to find domain controller to use via "
                             "DNS SRV record in domain %s for procotol %s",
                             realm_name.c_str(), protocols[i].c_str());
             dcsrvs = DnsSrvQuery("dc._msdcs." + realm_name, "kerberos", protocols[i]);
@@ -310,7 +310,7 @@ std::string get_dc_host(const std::string &realm_name, const std::string &site_n
     }
 
     if (dcsrvs.empty()) {
-        VERBOSE("Attempting to find a Domain Controller to use (DNS domain)");
+        VERBOSE("Attempting to find a domain controller to use (DNS domain)");
         dcsrvs = DnsSrvQuery(DnsSrvHost(realm_name, 0, 0, 0));
     }
 
@@ -326,7 +326,7 @@ std::string get_dc_host(const std::string &realm_name, const std::string &site_n
 	}
     }
 
-    VERBOSE("Found preferred Domain Controller: %s", bestdc.c_str());
+    VERBOSE("Found preferred domain controller: %s", bestdc.c_str());
 
     return bestdc;
 }

--- a/msktpass.cpp
+++ b/msktpass.cpp
@@ -77,7 +77,7 @@ int generate_new_password(msktutil_flags *flags)
             curr = 0;
             while (curr < 33 || curr > 126) {
                 if ((curr = getc(fp)) == EOF) {
-                    error_exit("failed to read from /dev/urandom");
+                    error_exit("Failed to read from /dev/urandom");
                 }
                 curr &= 0x7f;
                 chars_used++;
@@ -93,7 +93,7 @@ int generate_new_password(msktutil_flags *flags)
         }
     }
     fclose(fp);
-    VERBOSE(" Characters read from /dev/urandom = %d", chars_used);
+    VERBOSE("Characters read from /dev/urandom: %d", chars_used);
     return 0;
 }
 
@@ -101,7 +101,7 @@ int generate_new_password(msktutil_flags *flags)
 /* Try to set the the new Samba secret to <flags->password>. */
 static int set_samba_secret(msktutil_flags *flags)
 {
-    VERBOSE("Setting samba machine trust account password using '%s' command",
+    VERBOSE("Setting samba machine trust account password using command: %s",
             flags->samba_cmd.c_str());
 
     FILE *pipe;
@@ -109,7 +109,7 @@ static int set_samba_secret(msktutil_flags *flags)
 
     if (pipe == NULL) {
         fprintf(stdout,
-                "Could not execute '%s' command\n",
+                "Could not execute command: %s\n",
                 flags->samba_cmd.c_str()
             );
         return 1;
@@ -118,7 +118,7 @@ static int set_samba_secret(msktutil_flags *flags)
     size_t len = flags->password.length();
     if (fwrite(flags->password.c_str(), sizeof(char), len, pipe) != len) {
         fprintf(stdout,
-                "Write error putting password to '%s' command\n",
+                "Write error passing password to command: %s\n",
                 flags->samba_cmd.c_str()
             );
         return 1;
@@ -192,14 +192,14 @@ int set_password(msktutil_flags *flags)
                 if (!flags->server_behind_nat) {
                     fprintf(stderr,
                             "Error: krb5_set_password_using_ccache "
-                            "failed (%s)\n",
+                            "failed: %s\n",
                             error_message(ret)
                         );
                     return ret;
                 }
             } else {
                 fprintf(stderr,
-                        "Error: krb5_set_password_using_ccache failed (%s)\n",
+                        "Error: krb5_set_password_using_ccache failed: %s\n",
                         error_message(ret)
                     );
                 return ret;
@@ -222,7 +222,7 @@ int set_password(msktutil_flags *flags)
             } else {
                 princ_name = "host/" + flags->hostname;
             }
-            VERBOSE("Try using keytab for %s to change password",
+            VERBOSE("Trying to use keytab for %s to change password",
                     princ_name.c_str());
 
             KRB5Keytab keytab(flags->keytab_readname);
@@ -230,7 +230,7 @@ int set_password(msktutil_flags *flags)
             KRB5Creds local_creds(principal, keytab, "kadmin/changepw");
             creds.move_from(local_creds);
         } else if (flags->auth_type == AUTH_FROM_PASSWORD) {
-            VERBOSE("Try using default password for %s to change password",
+            VERBOSE("Trying to use default password for %s to change password",
                     flags->sAMAccountName.c_str());
 
             KRB5Principal principal(flags->sAMAccountName);
@@ -241,7 +241,7 @@ int set_password(msktutil_flags *flags)
             creds.move_from(local_creds);
         } else if ((flags->auth_type == AUTH_FROM_SUPPLIED_PASSWORD) ||
                    (flags->auth_type == AUTH_FROM_SUPPLIED_EXPIRED_PASSWORD)) {
-            VERBOSE("Try using supplied password for %s to change password",
+            VERBOSE("Trying to use supplied password for %s to change password",
                     flags->sAMAccountName.c_str());
             KRB5Principal principal(flags->sAMAccountName);
             KRB5Creds local_creds(principal,
@@ -249,7 +249,7 @@ int set_password(msktutil_flags *flags)
                                   "kadmin/changepw");
             creds.move_from(local_creds);
         } else /* shouldn't happen */
-            throw Exception("Error: unknown auth_type.");
+            throw Exception("Error: unknown auth_type");
 
         ret = krb5_change_password(g_context,
                                    creds.get(),
@@ -274,14 +274,14 @@ int set_password(msktutil_flags *flags)
                         "failed validation");
                 if (!flags->server_behind_nat) {
                     fprintf(stderr,
-                            "Error: krb5_change_password failed (%s)\n",
+                            "Error: krb5_change_password failed: %s\n",
                             error_message(ret)
                         );
                     return ret;
                 }
             } else {
                 fprintf(stderr,
-                        "Error: krb5_change_password failed (%s)\n",
+                        "Error: krb5_change_password failed: %s\n",
                         error_message(ret)
                     );
                 return ret;

--- a/msktutil.cpp
+++ b/msktutil.cpp
@@ -131,7 +131,7 @@ int parse_enctype(const std::string &value)
         enctype = 18;
     else {
         fprintf(stderr,
-                "Error: enctype = %s not supported. "
+                "Error: enctype %s not supported. "
                 "Supported enctype strings are\n", value.c_str()
             );
         fprintf(stderr, "  des-cbc-crc\n");
@@ -292,7 +292,7 @@ int finalize_exec(msktutil_exec *exec, msktutil_flags *flags)
      * than MAX_SAM_ACCOUNT_LEN characters */
     if (flags->sAMAccountName.length() > MAX_SAM_ACCOUNT_LEN) {
         fprintf(stderr,
-                "Error: The SAM name (%s) for this host is longer "
+                "Error: The sAMAccountName %s for this host is longer "
                 "than the maximum of MAX_SAM_ACCOUNT_LEN characters\n",
                 flags->sAMAccountName.c_str()
             );
@@ -302,7 +302,7 @@ int finalize_exec(msktutil_exec *exec, msktutil_flags *flags)
             );
         exit(1);
     }
-    VERBOSE("SAM Account Name is: %s", flags->sAMAccountName.c_str());
+    VERBOSE("sAMAccountName: %s", flags->sAMAccountName.c_str());
 
     if (exec->mode == MODE_CREATE && !flags->use_service_account) {
         exec->add_principals.push_back("host");
@@ -317,7 +317,7 @@ int finalize_exec(msktutil_exec *exec, msktutil_flags *flags)
     flags->auth_type = find_working_creds(flags);
     if (flags->auth_type == AUTH_NONE) {
         fprintf(stderr,
-                "Error: could not find any credentials to authenticate with. "
+                "Error: Could not find any credentials to authenticate with. "
                 "Neither keytab,\n"
                 "default machine password, nor calling user's tickets worked. "
                 "Try\n\"kinit\"ing yourself some tickets with permission to "
@@ -606,12 +606,12 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
     if (exec->mode == MODE_FLUSH) {
         if (flags->use_service_account) {
             fprintf(stdout,
-                    "Flushing all entries for service account %s from the keytab %s\n",
+                    "Flushing all entries for service account %s from keytab %s\n",
                     flags->sAMAccountName.c_str(),
                     flags->keytab_writename.c_str());
         } else {
             fprintf(stdout,
-                    "Flushing all entries for %s from the keytab %s\n",
+                    "Flushing all entries for %s from keytab %s\n",
                     flags->hostname.c_str(),
                     flags->keytab_writename.c_str());
         }
@@ -660,7 +660,7 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
         if (! ldap_check_account(flags)) {
             if (flags->password.empty()) {
                 fprintf(stderr,
-                        "Error: a new AD account needs to be created "
+                        "Error: A new AD account needs to be created "
                         "but there is no password.");
                 if (flags->dont_change_password) {
                     fprintf(stderr,
@@ -722,11 +722,11 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
 
         /* update keytab */
         if (flags->use_service_account) {
-            VERBOSE("Updating all entries for service account %s in the keytab %s",
+            VERBOSE("Updating all entries for service account %s in keytab %s",
                     flags->sAMAccountName.c_str(),
                     flags->keytab_writename.c_str());
         } else {
-            VERBOSE("Updating all entries for computer account %s in the keytab %s",
+            VERBOSE("Updating all entries for computer account %s in keytab %s",
                     flags->sAMAccountName.c_str(),
                     flags->keytab_writename.c_str());
         }
@@ -774,7 +774,7 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
         /* Check if computer account exists, update if so, error if
          * not. */
         if (!ldap_check_account(flags)) {
-            fprintf(stderr, "Error: the account %s does "
+            fprintf(stderr, "Error: The account %s does "
                             "not exist and cannot be "
                             "reset\n", flags->sAMAccountName.c_str());
             return 1;
@@ -789,7 +789,7 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
         wait_for_new_kvno(flags);
         return ret;
     } else if (exec->mode == MODE_CLEANUP) {
-        fprintf(stdout, "Cleaning keytab %s\n",
+        fprintf(stdout, "Cleaning keytab: %s\n",
                 flags->keytab_writename.c_str());
         cleanup_keytab(flags);
         return 0;
@@ -801,7 +801,7 @@ int execute(msktutil_exec *exec, msktutil_flags *flags)
 
 void msktutil_exec::set_mode(msktutil_mode mode) {
     if (this->mode != MODE_NONE) {
-        fprintf(stderr, "Error: only one mode argument may be provided.\n");
+        fprintf(stderr, "Error: Only one mode argument may be provided.\n");
         fprintf(stderr, "\nFor help, try running %s --help\n\n", PACKAGE_NAME);
         exit(1);
     }
@@ -900,7 +900,7 @@ int main(int argc, char *argv [])
                 exec->add_principals.push_back(argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No service principal given after '%s'\n",
+                        "Error: no service principal given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -912,7 +912,7 @@ int main(int argc, char *argv [])
                 exec->remove_principals.push_back(argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No service principal given after '%s'\n",
+                        "Error: no service principal given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -928,7 +928,7 @@ int main(int argc, char *argv [])
                 flags->hostname = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No name given after '%s'\n",
+                        "Error: no name given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -949,7 +949,7 @@ int main(int argc, char *argv [])
                 flags->old_account_password = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No password given after '%s'\n",
+                        "Error: no password given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -963,7 +963,7 @@ int main(int argc, char *argv [])
                                 flags->password = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No password given after '%s'\n",
+                        "Error: no password given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -983,7 +983,7 @@ int main(int argc, char *argv [])
                 flags->site = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No site given after '%s'\n",
+                        "Error: no site given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -997,7 +997,7 @@ int main(int argc, char *argv [])
                 set_supportedEncryptionTypes(flags, argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No enctype after '%s'\n",
+                        "Error: no enctype after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1067,7 +1067,7 @@ int main(int argc, char *argv [])
                 flags->sAMAccountName = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No name given after '%s'\n",
+                        "Error: no name given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1081,7 +1081,7 @@ int main(int argc, char *argv [])
                 flags->userPrincipalName = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No principal given after '%s'\n",
+                        "Error: no principal given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1095,7 +1095,7 @@ int main(int argc, char *argv [])
                 flags->keytab_file = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No file given after '%s'\n",
+                        "Error: no file given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1109,7 +1109,7 @@ int main(int argc, char *argv [])
                 flags->ldap_ou = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No base given after '%s'\n",
+                        "Error: no base given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1123,7 +1123,7 @@ int main(int argc, char *argv [])
                 flags->description = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No description given after '%s'\n",
+                        "Error: no description given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1137,7 +1137,7 @@ int main(int argc, char *argv [])
                 flags->server = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No server given after '%s'\n",
+                        "Error: no server given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1157,7 +1157,7 @@ int main(int argc, char *argv [])
                 flags->realm_name = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No realm given after '%s'\n",
+                        "Error: no realm given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1184,7 +1184,7 @@ int main(int argc, char *argv [])
                 flags->samba_cmd = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No command given after '%s'\n",
+                        "Error: no command given after '%s'\n",
                         argv[i -1]
                     );
                 goto error;
@@ -1203,7 +1203,7 @@ int main(int argc, char *argv [])
                 flags->keytab_auth_princ = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No principal given after '%s'\n",
+                        "Error: no principal given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1216,7 +1216,7 @@ int main(int argc, char *argv [])
                 flags->auto_update_interval = atoi(argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No number given after '%s'\n",
+                        "Error: no number given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1229,7 +1229,7 @@ int main(int argc, char *argv [])
                 flags->sasl_mechanisms = argv[i];
             } else {
                 fprintf(stderr,
-                        "Error: No SASL candidate mechanisms list given after '%s'\n",
+                        "Error: no SASL candidate mechanisms list given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1242,7 +1242,7 @@ int main(int argc, char *argv [])
                 flags->cleanup_days = atoi(argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No number given after '%s'\n",
+                        "Error: no number given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1255,7 +1255,7 @@ int main(int argc, char *argv [])
                 flags->cleanup_enctype = parse_enctype(argv[i]);
             } else {
                 fprintf(stderr,
-                        "Error: No number given after '%s'\n",
+                        "Error: no number given after '%s'\n",
                         argv[i - 1]
                     );
                 goto error;
@@ -1276,7 +1276,7 @@ int main(int argc, char *argv [])
         }
 
         /* Unrecognized */
-        fprintf(stderr, "Error: Unknown parameter (%s)\n", argv[i]);
+        fprintf(stderr, "Error: unknown parameter: %s\n", argv[i]);
         goto error;
     }
 
@@ -1337,7 +1337,7 @@ int main(int argc, char *argv [])
     if (flags->enctypes == VALUE_ON) {
         if ((flags->supportedEncryptionTypes | ALL_MS_KERB_ENCTYPES) != ALL_MS_KERB_ENCTYPES) {
             fprintf(stderr,
-                    "Error: Unsupported --enctypes must be integer that "
+                    "Error: unsupported --enctypes must be integer that "
                     "fits mask=0x%x\n",
                     ALL_MS_KERB_ENCTYPES
                 );
@@ -1365,7 +1365,7 @@ int main(int argc, char *argv [])
 
     if (exec->mode == MODE_NONE) {
         /* Default, no options present */
-        fprintf(stderr, "Error: No command given\n");
+        fprintf(stderr, "Error: no command given\n");
         goto error;
     }
 

--- a/msktutil.h
+++ b/msktutil.h
@@ -348,7 +348,7 @@ class KRB5Exception : public Exception
     krb5_error_code m_err;
   public:
     explicit KRB5Exception(const std::string &func, krb5_error_code err) :
-        Exception(sform("Error: %s failed (%s)", func.c_str(), error_message(err)))
+        Exception(sform("Error: %s failed: %s", func.c_str(), error_message(err)))
     { m_err = err; }
     krb5_error_code err() const throw() { return m_err; }
 
@@ -358,7 +358,7 @@ class LDAPException : public Exception
 {
   public:
     explicit LDAPException(const std::string &func, int err) :
-        Exception(sform("Error: %s failed (%s)", func.c_str(), ldap_err2string(err)))
+        Exception(sform("Error: %s failed: %s", func.c_str(), ldap_err2string(err)))
     {}
 };
 


### PR DESCRIPTION
* Highlight an error message instead of hiding in parentheses
* Capitalize start verbose messages
* Improve language style
* Clean up naming inconsistencies
* Use consistently colons as param value separator
* Denote UPNs, SPNs and SAM Account Names as such
* Capitalize after colon only if it is a full sentence or a paragraph

This closes #74 and closes #173