### PR TITLE
dns_lookup_kdc setting in create_fake_krb5_conf causes issue when usi…

### DIFF
--- a/msktconf.cpp
+++ b/msktconf.cpp
@@ -101,7 +101,7 @@ void create_fake_krb5_conf(msktutil_flags *flags)
 
     file << "[libdefaults]\n"
          << " default_realm = " << flags->realm_name << "\n"
-         << " dns_lookup_kdc = false\n"
+         << " dns_lookup_kdc = true\n"
          << " udp_preference_limit = 1\n"
          << " default_ccache_name = " << KRB5CCache::defaultName() << "\n";
 


### PR DESCRIPTION
…ng a trusted domain user to create computer account (#208)

When an account outside of the default realm is used Kerberos is not able to follow a cross-realm referral since the intermediate or target realm do not have a configuration block in the `[realms]` section. When setting `dns_lookup_kdc` to `true` Kerberos will still use our fixed (manually discovered) KDC for our default realm, but will resort to DNS for any other realm to follow referrals.

This fixes #208