### PR TITLE
configure.ac: fix linking with minimal LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@ AC_CHECK_LIB([ldap], [ldap_search_ext_s], , [AC_MSG_ERROR([libldap not found])])
 # versions, we have to explicitly link with lber.
 #
 AC_CHECK_LIB([lber], [ber_pvt_opt_on], , [AC_MSG_ERROR([liblber not found])])
-#AC_CHECK_LIB([com_err], [error_message], , [AC_MSG_ERROR([libcom_err not found])])
+AC_CHECK_LIB([com_err], [error_message], , [AC_MSG_ERROR([libcom_err not found])])
 #
 # LDAP_OPT_DIAGNOSTIC_MESSAGE is present from OpenLDAP 2.4 upwards, only.
 AC_CHECK_DECLS([LDAP_OPT_DIAGNOSTIC_MESSAGE], [], [], [[#include <ldap.h>]])


### PR DESCRIPTION
We directly call function `error_message()` from
`libcom_err`, and therefore have to explicitly link the msktutil binary to it. This used to work because `krb5-config --libs` always included the necessary `-lcom_err`, but for dynamic linking, recent versions started to omit transitive dependencies, and merely return the minimal `-lkrb5` instead.

The explicit check for `libcom_err` was removed in 189f8b356ab78936cbfad2b1d4d827cdc0028341 as part of Solaris-related fixes. However, this part of the
commit is dubious because the check itself looks
correct and required. It is unclear why Solaris builds would break, but in any case, a different fix is
appropriate here.

This change reverts a part of commit 189f8b356ab78936cbfad2b1d4d827cdc0028341. It addresses a build problem discussed as part of issue #211 (but is not related to the main topic of this issue).