### PR TITLE
Use getnameinfo(3) instead of inet_ntop(3)

### DIFF
--- a/msktname.cpp
+++ b/msktname.cpp
@@ -182,8 +182,8 @@ bool DnsSrvHost::validate(bool nocanon, std::string service) {
         }
         if (connect(sock, (struct sockaddr *) ai->ai_addr, ai->ai_addrlen) == -1) {
             int err = errno;
-            char addrstr[INET6_ADDRSTRLEN] = "";
-            (void) inet_ntop(ai->ai_family, ai->ai_addr, addrstr, INET6_ADDRSTRLEN);
+            char addrstr[NI_MAXHOST] = "";
+            (void) getnameinfo(ai->ai_addr, ai->ai_addrlen, addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
             VERBOSE("LDAP connection to %s failed: %s", addrstr, strerror(err));
             continue;
         }
@@ -202,8 +202,8 @@ bool DnsSrvHost::validate(bool nocanon, std::string service) {
 
         if (ret != 0) {
             int err = errno;
-            char addrstr[INET6_ADDRSTRLEN] = "";
-            (void) inet_ntop(ai->ai_family, ai->ai_addr, addrstr, INET6_ADDRSTRLEN);
+            char addrstr[NI_MAXHOST] = "";
+            (void) getnameinfo(ai->ai_addr, ai->ai_addrlen, addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
             VERBOSE("Error: getnameinfo failed for %s: %s", addrstr,
                     ret == EAI_SYSTEM ? strerror(err) : gai_strerror(ret));
             continue;


### PR DESCRIPTION
Instead of passing "struct sockaddr" one needs to cast by address family and retrieve sin_addr/sin6_addr.

Just this with bad PTR RRs. Some refs for the fix:

* https://gist.github.com/xuesongbj/81911c7e72d67aa2ef54e62632d7d8a8
* https://man7.org/linux/man-pages/man3/sockaddr.3type.html
* https://gist.github.com/jkomyno/45bee6e79451453c7bbdc22d033a282e
* https://stackoverflow.com/q/1276294/696632

Before:
```
 -- get_dc_host: Attempting to find domain controller to use via DNS SRV record in domain INNOMOTICS.NET for protocol tcp
 -- DnsSrvQuery: Running DNS SRV query for _kerberos._tcp.dc._msdcs.INNOMOTICS.NET
 -- validate: Found DC: cnpek01b12.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: sn1idc01.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: denbgvo004.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: sn1idc02.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: cnpek01b11.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: sn1sdc01.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: LDAP connection to 16.2.1.133 failed: Operation timed out
 -- validate: Found DC: dembgvo003.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
 -- validate: Found DC: sn1sdc00.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 16.2.1.133: Name does not resolve
```

After:
```
 -- DnsSrvQuery: Running DNS SRV query for _kerberos._tcp.dc._msdcs.INNOMOTICS.NET
 -- validate: Found DC: cnpek01b12.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 10.64.90.133: Name does not resolve
 -- validate: Found DC: defthwad01.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 10.64.22.140: Name does not resolve
 -- validate: Found DC: sn1idc01.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 10.64.48.91: Name does not resolve
 -- validate: Found DC: sn1sdc01.innomotics.net. Checking availability...
 -- validate: Error: getnameinfo failed for 10.64.96.179: Name does not resolve
...
```