### PR TITLE
CI enhancements

### DIFF
--- a/.github/workflows/msktutil-archs.yml
+++ b/.github/workflows/msktutil-archs.yml
@@ -71,4 +71,4 @@ jobs:
           run: |
             ${CC} --version
             ./autogen.sh
-            ./configure && make
+            ./configure && make && ./msktutil --version

--- a/.github/workflows/msktutil-freebsd.yml
+++ b/.github/workflows/msktutil-freebsd.yml
@@ -45,4 +45,4 @@ jobs:
           esac
           ${CC} --version
           ./autogen.sh
-          ./configure && make
+          ./configure && make && ./msktutil --version

--- a/.github/workflows/msktutil-macos.yml
+++ b/.github/workflows/msktutil-macos.yml
@@ -39,4 +39,4 @@ jobs:
         ./autogen.sh
         ./configure \
            --with-ldapdir=/usr/local/opt/openldap \
-           --with-krb5-config=/usr/local/opt/krb5/bin/krb5-config && make
+           --with-krb5-config=/usr/local/opt/krb5/bin/krb5-config && make && ./msktutil --version

--- a/.github/workflows/msktutil-solaris.yml
+++ b/.github/workflows/msktutil-solaris.yml
@@ -1,0 +1,42 @@
+name: msktutil Solaris
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build on Solaris
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { cc-version: gcc }
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Build msktutil with ${{ matrix.cfg.cc-version }}
+      id: build
+      uses: vmactions/solaris-vm@v1
+      with:
+        release: "11.4-gcc"
+        mem: 2048
+        usesh: true
+        prepare: |
+          # basic dependencies
+          pkgutil -y -i autoconf sasl_gssapi gmake libkrb5_dev openldap_dev sasl_dev
+        run: |
+          case "${{ matrix.cfg.cc-version }}" in
+            gcc)
+              pkgutil -y -i gcc5g++
+              export PATH=/opt/csw/bin:$PATH
+              export CC=gcc
+              export CXX=g++
+              ;;
+          esac
+          ${CC} --version
+          ./autogen.sh
+          ./configure && make

--- a/.github/workflows/msktutil-solaris.yml
+++ b/.github/workflows/msktutil-solaris.yml
@@ -39,4 +39,4 @@ jobs:
           esac
           ${CC} --version
           ./autogen.sh
-          ./configure && make
+          ./configure && make && ./msktutil --version

--- a/.github/workflows/msktutil.yml
+++ b/.github/workflows/msktutil.yml
@@ -138,4 +138,4 @@ jobs:
         esac
         ${CC} --version
         ./autogen.sh
-        ./configure && make
+        ./configure && make && ./msktutil --version

--- a/.github/workflows/msktutil.yml
+++ b/.github/workflows/msktutil.yml
@@ -29,6 +29,8 @@ jobs:
           - { container: 'quay.io/centos/centos:stream9', cc-version: clang }
           - { container: 'fedora:latest', cc-version: gcc }
           - { container: 'fedora:latest', cc-version: clang }
+          - { container: 'registry.access.redhat.com/ubi9/ubi:latest', cc-version: gcc }
+          - { container: 'registry.access.redhat.com/ubi9/ubi:latest', cc-version: clang }
 
     steps:
     - name: Install compiler ${{ matrix.cfg.cc-version }}
@@ -70,6 +72,10 @@ jobs:
             dnf -y install ${{ matrix.cfg.cc-version }}
             ${{ matrix.cfg.cc-version }} --version
             ;;
+          */ubi:*)
+            cat /etc/redhat-release
+            dnf -y install ${{ matrix.cfg.cc-version }}
+            ${{ matrix.cfg.cc-version }} --version
         esac
 
     - name: Install msktutil dependencies ${{ matrix.cfg.cc-version }}
@@ -102,7 +108,7 @@ jobs:
             yum -y install \
               cyrus-sasl-devel krb5-devel openldap-devel
             ;;
-          */centos:*)
+          */centos:*|*/ubi:*)
             # basic packages
             dnf -y install \
               autoconf automake gcc-c++ libtool make pkgconfig which


### PR DESCRIPTION
Extend CI tests to cover builds on UBI9 (RHEL9) and Solaris, and - barring a proper testsuite - add a minimalist runtime check of the resulting binary after each build.